### PR TITLE
Redirect to Amplecen ID and support cookie domain

### DIFF
--- a/app/(account)/account/update-password/page.tsx
+++ b/app/(account)/account/update-password/page.tsx
@@ -91,10 +91,10 @@ export default function UpdatePasswordPage() {
           </CardHeader>
           <CardContent className="space-y-3">
             <Button asChild className="w-full">
-              <Link href="/auth/reset-password">Request a new reset link</Link>
+              <a href={`${process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com"}/auth/reset-password`}>Request a new reset link</a>
             </Button>
             <Button asChild variant="outline" className="w-full">
-              <Link href="/login">Back to login</Link>
+              <a href={`${process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com"}/login`}>Back to login</a>
             </Button>
           </CardContent>
         </Card>

--- a/app/(auth)/auth/auth-code-error/page.tsx
+++ b/app/(auth)/auth/auth-code-error/page.tsx
@@ -33,11 +33,11 @@ export default function AuthCodeErrorPage() {
 
           <div className="space-y-2">
             <Button asChild className="w-full">
-              <Link href="/signup">Try signing up again</Link>
+              <a href={`${process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com"}/signup`}>Try signing up again</a>
             </Button>
             
             <Button asChild variant="outline" className="w-full">
-              <Link href="/login">Back to login</Link>
+              <a href={`${process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com"}/login`}>Back to login</a>
             </Button>
           </div>
 

--- a/app/(auth)/signup/intro/page.tsx
+++ b/app/(auth)/signup/intro/page.tsx
@@ -149,9 +149,12 @@ export default function IntroPage() {
             </Button>
             <p className="text-sm text-muted-foreground mt-3">
               Already have an account?{" "}
-              <Link href="/login" className="text-primary hover:text-primary/80 font-medium transition-colors">
+              <a
+                href={`${process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com"}/login`}
+                className="text-primary hover:text-primary/80 font-medium transition-colors"
+              >
                 Sign in
-              </Link>
+              </a>
             </p>
           </div>
         </div>

--- a/app/(dashboard)/dashboard/journal/new/page.tsx
+++ b/app/(dashboard)/dashboard/journal/new/page.tsx
@@ -11,6 +11,7 @@ import { getUser } from "@/app/actions/auth";
 import { getEncryptionToken } from "@/app/actions/encryption";
 import { redirect } from "next/navigation";
 import NewJournalClient from "./new-journal-client";
+import { getAmplecenLoginUrl } from "@/lib/auth-redirect";
 
 export default async function NewJournalPage() {
   const [user, encryptionToken] = await Promise.all([
@@ -19,7 +20,7 @@ export default async function NewJournalPage() {
   ]);
 
   if (!user) {
-    redirect("/login");
+    redirect(getAmplecenLoginUrl('/dashboard/journal/new'));
   }
 
   return (

--- a/app/(dashboard)/settings/billing-history/page.tsx
+++ b/app/(dashboard)/settings/billing-history/page.tsx
@@ -5,11 +5,12 @@ import { getUser } from "@/app/actions/auth"
 import { redirect } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import { BillingHistorySection } from "./_components/billing-history-section"
+import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
 
 export default async function BillingHistoryPage() {
   const user = await getUser()
   if (!user) {
-    redirect("/login")
+    redirect(getAmplecenLoginUrl('/settings/billing-history'))
   }
   
   const supabase = await createClient()

--- a/app/(dashboard)/settings/connections/page.tsx
+++ b/app/(dashboard)/settings/connections/page.tsx
@@ -4,6 +4,8 @@
 import { getUser, getUserIdentities } from "@/app/actions/auth"
 import { redirect } from "next/navigation"
 import { ConnectionsSection } from "./_components/connections-section"
+import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
+import { ExternalLink } from "lucide-react"
 
 interface ConnectionsPageProps {
   searchParams: Promise<{ linked?: string }>
@@ -13,12 +15,34 @@ export default async function ConnectionsPage({ searchParams }: ConnectionsPageP
   const user = await getUser()
   
   if (!user) {
-    redirect("/login")
+    redirect(getAmplecenLoginUrl('/settings/connections'))
   }
 
   const identities = await getUserIdentities()
   const params = await searchParams
   const linkedProvider = params.linked || null
 
-  return <ConnectionsSection identities={identities} linkedProvider={linkedProvider} />
+  const accountsSettingsUrl = `${process.env.NEXT_PUBLIC_ACCOUNTS_URL || 'https://accounts.amplecen.com'}/settings/connections`
+
+  return (
+    <div className="space-y-6">
+      {/* Moved notice */}
+      <div className="flex items-start gap-3 p-4 rounded-xl bg-primary/5 border border-primary/20">
+        <ExternalLink className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+        <p className="text-sm text-muted-foreground">
+          Connected accounts are now managed in your{" "}
+          <strong className="text-foreground">Amplecen ID</strong>.{" "}
+          <a
+            href={accountsSettingsUrl}
+            className="text-primary hover:underline font-medium"
+          >
+            Go to Account Settings →
+          </a>
+        </p>
+      </div>
+
+      <ConnectionsSection identities={identities} linkedProvider={linkedProvider} />
+    </div>
+  )
 }
+

--- a/app/(dashboard)/settings/delete-account/page.tsx
+++ b/app/(dashboard)/settings/delete-account/page.tsx
@@ -4,12 +4,13 @@
 import { getUser } from "@/app/actions/auth"
 import { redirect } from "next/navigation"
 import { DeleteAccountSection } from "./_components/delete-account-section"
+import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
 
 export default async function DeleteAccountPage() {
   const user = await getUser()
   
   if (!user) {
-    redirect("/login")
+    redirect(getAmplecenLoginUrl('/settings/delete-account'))
   }
 
   return (

--- a/app/(dashboard)/settings/onboarding/page.tsx
+++ b/app/(dashboard)/settings/onboarding/page.tsx
@@ -5,12 +5,13 @@ import { getUser } from "@/app/actions/auth"
 import { getUserPreferences } from "@/app/actions/settings"
 import { redirect } from "next/navigation"
 import { OnboardingSection } from "./_components/onboarding-section"
+import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
 
 export default async function OnboardingPage() {
   const user = await getUser()
   
   if (!user) {
-    redirect("/login")
+    redirect(getAmplecenLoginUrl('/settings/onboarding'))
   }
 
   const preferences = await getUserPreferences()

--- a/app/(dashboard)/settings/profile/page.tsx
+++ b/app/(dashboard)/settings/profile/page.tsx
@@ -4,12 +4,13 @@
 import { getFullUser } from "@/app/actions/auth"
 import { redirect } from "next/navigation"
 import { ProfileSection } from "./_components/profile-section"
+import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
 
 export default async function ProfilePage() {
   const user = await getFullUser()
   
   if (!user) {
-    redirect("/login")
+    redirect(getAmplecenLoginUrl('/settings/profile'))
   }
 
   return (

--- a/app/(dashboard)/settings/security/page.tsx
+++ b/app/(dashboard)/settings/security/page.tsx
@@ -4,14 +4,38 @@
 import { createClient } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
 import SecuritySection from "./_components/security-section"
+import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
+import { ExternalLink } from "lucide-react"
 
 export default async function SecurityPage() {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 
   if (!user) {
-    redirect("/login")
+    redirect(getAmplecenLoginUrl('/settings/security'))
   }
 
-  return <SecuritySection userId={user.id} />
+  const accountsSettingsUrl = `${process.env.NEXT_PUBLIC_ACCOUNTS_URL || 'https://accounts.amplecen.com'}/settings/security`
+
+  return (
+    <div className="space-y-6">
+      {/* Moved notice */}
+      <div className="flex items-start gap-3 p-4 rounded-xl bg-primary/5 border border-primary/20">
+        <ExternalLink className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+        <p className="text-sm text-muted-foreground">
+          Security settings are now managed in your{" "}
+          <strong className="text-foreground">Amplecen ID</strong>.{" "}
+          <a
+            href={accountsSettingsUrl}
+            className="text-primary hover:underline font-medium"
+          >
+            Go to Account Settings →
+          </a>
+        </p>
+      </div>
+
+      <SecuritySection userId={user.id} />
+    </div>
+  )
 }
+

--- a/app/(dashboard)/settings/subscription/page.tsx
+++ b/app/(dashboard)/settings/subscription/page.tsx
@@ -5,12 +5,13 @@ import { getUser } from "@/app/actions/auth"
 import { redirect } from "next/navigation"
 import { SubscriptionSection } from "./_components/subscription-section"
 import { createClient } from "@/lib/supabase/server"
+import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
 
 export default async function SubscriptionPage() {
   const user = await getUser()
   
   if (!user) {
-    redirect("/login")
+    redirect(getAmplecenLoginUrl('/settings/subscription'))
   }
 
   // Fetch real subscription status

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -56,7 +56,7 @@ export async function signOut() {
   const supabase = await createClient()
 
   await supabase.auth.signOut()
-  redirect('/login')
+  redirect(process.env.NEXT_PUBLIC_ACCOUNTS_URL || 'https://accounts.amplecen.com')
 }
 
 export async function getUser() {

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -90,7 +90,8 @@ export default function OnboardingPage() {
     const { data: { user }, error } = await supabase.auth.getUser();
 
     if (error || !user) {
-      router.push("/login");
+      window.location.href =
+        process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com";
       return;
     }
 

--- a/components/OnboardingCheck.tsx
+++ b/components/OnboardingCheck.tsx
@@ -2,11 +2,9 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 
 export default function OnboardingCheck({ children }: { children: React.ReactNode }) {
-  const router = useRouter();
   const supabase = createClient();
 
   useEffect(() => {
@@ -15,9 +13,11 @@ export default function OnboardingCheck({ children }: { children: React.ReactNod
 
   async function checkOnboardingStatus() {
     const { data: { user } } = await supabase.auth.getUser();
-    
+
     if (!user) {
-      router.push("/login");
+      // Middleware should catch this first — this is a safety net
+      window.location.href =
+        process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com";
       return;
     }
 
@@ -30,9 +30,10 @@ export default function OnboardingCheck({ children }: { children: React.ReactNod
 
     if (!preferences) {
       // User hasn't completed onboarding, redirect
-      router.push("/onboarding");
+      window.location.href = "/onboarding";
     }
   }
 
   return <>{children}</>;
 }
+

--- a/components/auth/signout-button.tsx
+++ b/components/auth/signout-button.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { createClient } from "@/lib/supabase/client";
-import { useRouter } from "next/navigation";
 
 export default function SignOutButton() {
-    const router = useRouter();
-
   const supabase = createClient();
 
   async function handleSignOut() {
     await supabase.auth.signOut({});
-    router.push("/login");
+    // Full page redirect so the cleared cookie is visible to the new domain
+    window.location.href =
+      process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com";
   }
 
   return (
@@ -22,3 +21,4 @@ export default function SignOutButton() {
     </button>
   );
 }
+

--- a/components/landing/navbar-client.tsx
+++ b/components/landing/navbar-client.tsx
@@ -92,12 +92,12 @@ const NavbarClient: React.FC<NavbarProps> = ({ user }) => {
               ) : (
                 <>
                   {/* Logged out state */}
-                  <Link
-                    href="/login"
+                  <a
+                    href={`${process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com"}/login`}
                     className="hidden sm:flex px-3 md:px-4 py-1.5 md:py-2 backdrop-blur-xl bg-primary/5 hover:bg-primary/10 border border-primary/20 hover:border-primary/40 rounded-lg text-sm md:text-base text-foreground hover:text-primary transition-all duration-300 font-medium btn-premium"
                   >
                     Log in
-                  </Link>
+                  </a>
                   <Link
                     href="/signup/intro"
                     className="flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 md:px-5 py-1.5 sm:py-2 md:py-2.5 bg-gradient-to-r from-primary to-accent text-primary-foreground rounded-lg text-sm sm:text-base font-semibold hover:shadow-xl hover:shadow-primary/30 transition-all duration-300 hover:scale-105 group btn-premium"
@@ -143,13 +143,13 @@ const NavbarClient: React.FC<NavbarProps> = ({ user }) => {
                 </a>
               ))}
               {!user && (
-                <Link
-                  href="/login"
+                <a
+                  href={`${process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com"}/login`}
                   onClick={closeMobileMenu}
                   className="sm:hidden block px-4 py-2.5 backdrop-blur-xl bg-primary/5 border border-primary/20 rounded-lg text-foreground hover:text-primary text-center transition-all duration-300 font-medium"
                 >
                   Log in
-                </Link>
+                </a>
               )}
             </div>
           </div>

--- a/components/settings/delete-account-modal.tsx
+++ b/components/settings/delete-account-modal.tsx
@@ -64,7 +64,8 @@ export function DeleteAccountModal() {
       setIsDeleting(false)
     } else {
       toast.success("Account deleted. It's not you, it's... well, goodbye. 👋")
-      router.push("/login")
+      window.location.href =
+        process.env.NEXT_PUBLIC_ACCOUNTS_URL || "https://accounts.amplecen.com"
     }
   }
 

--- a/lib/auth-redirect.ts
+++ b/lib/auth-redirect.ts
@@ -1,0 +1,28 @@
+/**
+ * Amplecen ID — Auth Redirect Helpers
+ *
+ * Use these instead of hardcoding `/login` anywhere in Rhythmé.
+ * The accounts URL is driven by NEXT_PUBLIC_ACCOUNTS_URL so it works
+ * in both local dev (localhost:3001) and production (accounts.amplecen.com).
+ */
+
+/**
+ * Build the full Amplecen ID login URL with a return_to param
+ * pointing back to this Rhythmé path.
+ *
+ * @param returnPath - the Rhythmé path to return to after login (e.g. '/dashboard')
+ * @returns full URL string, e.g. https://accounts.amplecen.com/login?return_to=https%3A%2F%2Frythme...
+ */
+export function getAmplecenLoginUrl(returnPath: string = '/dashboard'): string {
+  const accountsUrl = process.env.NEXT_PUBLIC_ACCOUNTS_URL || 'https://accounts.amplecen.com'
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://rhythme.amplecen.com'
+  const returnTo = encodeURIComponent(`${appUrl}${returnPath}`)
+  return `${accountsUrl}/login?return_to=${returnTo}`
+}
+
+/**
+ * Build the accounts app home URL (for sign-out redirects).
+ */
+export function getAmplecenHomeUrl(): string {
+  return process.env.NEXT_PUBLIC_ACCOUNTS_URL || 'https://accounts.amplecen.com'
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,8 +1,20 @@
 import { createBrowserClient } from '@supabase/ssr'
 
 export function createClient() {
+  const cookieDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN // '.amplecen.com' in prod, unset in dev
+
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    cookieDomain
+      ? {
+          cookieOptions: {
+            domain: cookieDomain,
+            path: '/',
+            sameSite: 'lax' as const,
+            secure: true,
+          },
+        }
+      : undefined
   )
-}
+}

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -6,6 +6,8 @@ export async function updateSession(request: NextRequest) {
     request,
   })
 
+  const cookieDomain = process.env.COOKIE_DOMAIN // '.amplecen.com' in prod, unset in dev
+
   // With Fluid compute, don't put this client in a global environment
   // variable. Always create a new one on each request.
   const supabase = createServerClient(
@@ -21,7 +23,17 @@ export async function updateSession(request: NextRequest) {
           supabaseResponse = NextResponse.next({
             request,
           })
-          cookiesToSet.forEach(({ name, value, options }) => supabaseResponse.cookies.set(name, value, options))
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, {
+              ...options,
+              ...(cookieDomain && {
+                domain: cookieDomain,
+                path: '/',
+                sameSite: 'lax' as const,
+                secure: true,
+              }),
+            })
+          )
         },
       },
     }
@@ -37,40 +49,20 @@ export async function updateSession(request: NextRequest) {
 
   const user = data?.claims
 
-//   if (
-//     !user &&
-//     !request.nextUrl.pathname.startsWith('/login') &&
-//     !request.nextUrl.pathname.startsWith('/auth')
-//   ) {
-//     // no user, potentially respond by redirecting the user to the login page
-//     const url = request.nextUrl.clone()
-//     url.pathname = '/login'
-//     return NextResponse.redirect(url)
-//   }
   // Protected routes that require authentication
-  const isProtectedRoute = 
+  const isProtectedRoute =
     request.nextUrl.pathname.startsWith('/dashboard') ||
     request.nextUrl.pathname.startsWith('/settings') ||
     request.nextUrl.pathname.startsWith('/user')
 
-  // Public routes that logged-in users shouldn't access
-  const isAuthRoute = 
-    request.nextUrl.pathname === '/login' ||
-    request.nextUrl.pathname === '/signup'
-
-  // If user is not logged in and trying to access protected route
+  // If user is not logged in and trying to access a protected route,
+  // redirect to Amplecen ID with return_to so they land back here after login.
   if (!user && isProtectedRoute) {
-    const redirectUrl = new URL('/login', request.url)
-    // Save the page they were trying to access
-    redirectUrl.searchParams.set('redirect', request.nextUrl.pathname)
-    return NextResponse.redirect(redirectUrl)
+    const accountsUrl = process.env.NEXT_PUBLIC_ACCOUNTS_URL || 'https://accounts.amplecen.com'
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://rhythme.amplecen.com'
+    const returnTo = encodeURIComponent(`${appUrl}${request.nextUrl.pathname}`)
+    return NextResponse.redirect(`${accountsUrl}/login?return_to=${returnTo}`)
   }
-
-  // If user is logged in and trying to access auth pages, redirect to dashboard
-  if (user && isAuthRoute) {
-    return NextResponse.redirect(new URL('/dashboard', request.url))
-  }
-
 
   // IMPORTANT: You *must* return the supabaseResponse object as it is. If you're
   // creating a new response object with NextResponse.next() make sure to:
@@ -86,4 +78,4 @@ export async function updateSession(request: NextRequest) {
   // of sync and terminate the user's session prematurely!
 
   return supabaseResponse
-}
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers'
 
 export async function createClient() {
   const cookieStore = await cookies()
+  const cookieDomain = process.env.COOKIE_DOMAIN // '.amplecen.com' in prod, unset in dev
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -14,7 +15,17 @@ export async function createClient() {
         },
         setAll(cookiesToSet) {
           try {
-            cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, {
+                ...options,
+                ...(cookieDomain && {
+                  domain: cookieDomain,
+                  path: '/',
+                  sameSite: 'lax' as const,
+                  secure: true,
+                }),
+              })
+            )
           } catch {
             // The `setAll` method was called from a Server Component.
             // This can be ignored if you have middleware refreshing
@@ -24,4 +35,4 @@ export async function createClient() {
       },
     }
   )
-}
+}


### PR DESCRIPTION
Introduce centralized auth redirect helpers and switch auth flows to the Amplecen ID app. Added lib/auth-redirect.getAmplecenLoginUrl and used it across pages to redirect unauthenticated users (and replaced local /login links with the accounts URL). Update sign-out, onboarding, and delete-account flows to perform full-page redirects to the accounts domain. Enhance Supabase clients (browser/server/proxy) to honor a COOKIE_DOMAIN/cookieDomain for cross-subdomain cookies and ensure middleware redirects unauthenticated requests to the accounts login with a return_to param. Add UI notices for moved settings (connections/security) linking to Amplecen ID.