### PR TITLE
Integrate Dodo payments & normalize billing

### DIFF
--- a/app/(dashboard)/settings/billing-history/_components/billing-history-section.tsx
+++ b/app/(dashboard)/settings/billing-history/_components/billing-history-section.tsx
@@ -1,6 +1,3 @@
-// app/(dashboard)/settings/billing-history/_components/billing-history-section.tsx
-// Billing history with flat design
-
 "use client"
 
 import { Receipt, Download, Info } from "lucide-react"
@@ -8,12 +5,30 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 
 interface BillingHistorySectionProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  invoices: any[]
+  invoices: {
+    id: string
+    provider_payment_id?: string | null
+    plan_key?: string | null
+    amount?: number | string | null
+    currency?: string | null
+    status: string
+    paid_at?: string | null
+    receipt_url?: string | null
+  }[]
 }
 
 export function BillingHistorySection({ invoices }: BillingHistorySectionProps) {
   const hasInvoices = invoices && invoices.length > 0
+
+  const formatMoney = (amount?: number | string | null, currency = "USD") => {
+    if (amount == null) return "Managed by Dodo"
+    const parsedAmount = typeof amount === "string" ? Number(amount) : amount
+    if (!Number.isFinite(parsedAmount)) return "Managed by Dodo"
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+    }).format(parsedAmount)
+  }
 
   return (
     <div className="space-y-6">
@@ -27,11 +42,10 @@ export function BillingHistorySection({ invoices }: BillingHistorySectionProps) 
         </div>
       ) : (
         <>
-          {/* Invoice List */}
           <div className="space-y-3">
-            {invoices.map((invoice, idx) => (
+            {invoices.map((invoice) => (
               <div
-                key={invoice.id || idx}
+                key={invoice.id}
                 className="flex items-center justify-between p-4 rounded-lg bg-muted/30 border border-border/50 transition-colors hover:bg-muted/50"
               >
                 <div className="flex items-center gap-4">
@@ -40,33 +54,43 @@ export function BillingHistorySection({ invoices }: BillingHistorySectionProps) 
                   </div>
                   <div>
                     <div className="flex items-center gap-2">
-                      <span className="font-medium text-sm">INV-{invoice.id ? invoice.id.slice(0, 6).toUpperCase() : (idx + 1000)}</span>
+                      <span className="font-medium text-sm">
+                        INV-{invoice.provider_payment_id ? invoice.provider_payment_id.slice(-8).toUpperCase() : invoice.id.slice(0, 6).toUpperCase()}
+                      </span>
                       <Badge variant="outline" className="text-xs bg-green-500/10 text-green-500 border-green-200">
                         {invoice.status}
                       </Badge>
                     </div>
                     <p className="text-xs text-muted-foreground capitalize">
-                      {new Date(invoice.date).toLocaleDateString("en-US", { year: 'numeric', month: 'short', day: 'numeric'})} • {invoice.plan_type} Plan
+                      {invoice.paid_at ? new Date(invoice.paid_at).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "Processing"} - {invoice.plan_key || "Premium"} Plan
                     </p>
                   </div>
                 </div>
-                
+
                 <div className="flex items-center gap-4">
-                  <span className="font-medium">${invoice.amount}</span>
-                  <Button variant="ghost" size="sm" className="gap-1 shadow-sm">
-                    <Download className="h-4 w-4" />
-                    Receipt
-                  </Button>
+                  <span className="font-medium">{formatMoney(invoice.amount, invoice.currency || "USD")}</span>
+                  {invoice.receipt_url ? (
+                    <Button variant="ghost" size="sm" className="gap-1 shadow-sm" asChild>
+                      <a href={invoice.receipt_url} target="_blank" rel="noreferrer">
+                        <Download className="h-4 w-4" />
+                        Receipt
+                      </a>
+                    </Button>
+                  ) : (
+                    <Button variant="ghost" size="sm" className="gap-1 shadow-sm" disabled>
+                      <Download className="h-4 w-4" />
+                      Receipt
+                    </Button>
+                  )}
                 </div>
               </div>
             ))}
           </div>
 
-          {/* Info */}
           <div className="flex items-start gap-2 p-4 rounded-lg bg-muted/30 border border-border/50">
             <Info className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
             <p className="text-sm text-muted-foreground leading-relaxed">
-              Invoices are generated automatically after each billing cycle. Need help with billing? 
+              Invoices are generated automatically after each billing cycle. Need help with billing?
               <a href="mailto:support@rhythme.io" className="text-primary font-medium hover:underline ml-1">Contact support</a>
             </p>
           </div>

--- a/app/(dashboard)/settings/billing-history/page.tsx
+++ b/app/(dashboard)/settings/billing-history/page.tsx
@@ -1,26 +1,23 @@
-// app/(dashboard)/settings/billing-history/page.tsx
-// Billing history settings page
-
 import { getUser } from "@/app/actions/auth"
 import { redirect } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import { BillingHistorySection } from "./_components/billing-history-section"
 import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
+import { RHYTHME_PRODUCT_KEY } from "@/lib/payments/dodo"
 
 export default async function BillingHistoryPage() {
   const user = await getUser()
   if (!user) {
-    redirect(getAmplecenLoginUrl('/settings/billing-history'))
+    redirect(getAmplecenLoginUrl("/settings/billing-history"))
   }
-  
+
   const supabase = await createClient()
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("billing_history")
-    .eq("id", user.id)
-    .single()
+  const { data: invoices } = await supabase
+    .from("billing_events")
+    .select("id, provider_payment_id, plan_key, amount, currency, status, paid_at, receipt_url")
+    .eq("user_id", user.id)
+    .eq("product_key", RHYTHME_PRODUCT_KEY)
+    .order("paid_at", { ascending: false, nullsFirst: false })
 
-  const invoices = Array.isArray(profile?.billing_history) ? profile.billing_history : []
-
-  return <BillingHistorySection invoices={invoices} />
+  return <BillingHistorySection invoices={invoices ?? []} />
 }

--- a/app/(dashboard)/settings/billing/billing-settings-content.tsx
+++ b/app/(dashboard)/settings/billing/billing-settings-content.tsx
@@ -35,7 +35,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import { toast } from "sonner"
 import { usePremium } from "@/hooks/use-premium"
 
-// Updated pricing (display only — actual charge is from Razorpay plan config in INR)
+// Display pricing only. Dodo product configuration is the source of truth for charges.
 const pricing = {
   monthly: { starter: 0, premium: 9.99 },
   yearly: { starter: 0, premium: 99.99 }

--- a/app/(dashboard)/settings/profile/page.tsx
+++ b/app/(dashboard)/settings/profile/page.tsx
@@ -5,6 +5,7 @@ import { getFullUser } from "@/app/actions/auth"
 import { redirect } from "next/navigation"
 import { ProfileSection } from "./_components/profile-section"
 import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
+import { createClient } from "@/lib/supabase/server"
 
 export default async function ProfilePage() {
   const user = await getFullUser()
@@ -13,14 +14,28 @@ export default async function ProfilePage() {
     redirect(getAmplecenLoginUrl('/settings/profile'))
   }
 
+  const supabase = await createClient()
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name, email, avatar_url, created_at")
+    .eq("id", user.id)
+    .maybeSingle()
+
+  const name =
+    profile?.full_name ||
+    user.user_metadata?.full_name ||
+    user.user_metadata?.name ||
+    user.email?.split("@")[0] ||
+    "User"
+
   return (
     <ProfileSection
       user={{
         id: user.id,
-        name: user.user_metadata?.full_name || user.user_metadata?.name || user.email?.split("@")[0] || "User",
-        email: user.email || "",
-        avatar: user.user_metadata?.avatar_url || `https://avatar.vercel.sh/${user.email}`,
-        createdAt: user.created_at,
+        name,
+        email: profile?.email || user.email || "",
+        avatar: profile?.avatar_url || user.user_metadata?.avatar_url || `https://avatar.vercel.sh/${user.email}`,
+        createdAt: profile?.created_at || user.created_at,
       }}
     />
   )

--- a/app/(dashboard)/settings/subscription/_components/subscription-section.tsx
+++ b/app/(dashboard)/settings/subscription/_components/subscription-section.tsx
@@ -1,5 +1,5 @@
 // app/(dashboard)/settings/subscription/_components/subscription-section.tsx
-// Subscription management with Razorpay checkout integration
+// Subscription management with Dodo Payments checkout integration
 
 "use client"
 
@@ -28,13 +28,14 @@ import {
   ChevronDown,
   ChevronUp,
   Loader2,
+  CreditCard,
+  AlertTriangle,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { motion, AnimatePresence } from "framer-motion"
 import { toast } from "sonner"
-import { usePremium } from "@/hooks/use-premium"
 
-// Display pricing (actual charge is from Razorpay plan config in INR)
+// Display pricing. Dodo product ids remain the source of truth for actual charges.
 const pricing = {
   monthly: { starter: 0, premium: 9.99 },
   yearly: { starter: 0, premium: 99.99 }
@@ -76,18 +77,44 @@ interface SubscriptionSectionProps {
   currentPlan: "starter" | "premium"
   details?: {
     plan?: string;
-    amountPaid?: number;
-    endDate?: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    billingHistory?: any[];
+    status?: string;
+    amount?: number | string;
+    currency?: string;
+    billingInterval?: string;
+    currentPeriodEnd?: string;
+    cancelAtPeriodEnd?: boolean;
+    subscriptionId?: string;
+    billingHistory?: BillingHistoryItem[];
   }
+}
+
+interface BillingHistoryItem {
+  id: string
+  provider_payment_id?: string | null
+  plan_key?: string | null
+  amount?: number | string | null
+  currency?: string | null
+  status: string
+  paid_at?: string | null
+  receipt_url?: string | null
+}
+
+function formatMoney(amount?: number | string | null, currency = "USD") {
+  if (amount == null) return "Managed by Dodo"
+  const parsedAmount = typeof amount === "string" ? Number(amount) : amount
+  if (!Number.isFinite(parsedAmount)) return "Managed by Dodo"
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(parsedAmount)
 }
 
 export function SubscriptionSection({ currentPlan, details }: SubscriptionSectionProps) {
   const [billingCycle, setBillingCycle] = useState<"monthly" | "yearly">("yearly")
   const [showAllFeatures, setShowAllFeatures] = useState(false)
   const [isUpgrading, setIsUpgrading] = useState(false)
-  const { refetch } = usePremium()
+  const [isUpdatingPayment, setIsUpdatingPayment] = useState(false)
+  const [isCancelling, setIsCancelling] = useState(false)
   
   const isPremium = currentPlan === "premium"
   const yearlyPrice = pricing.yearly.premium
@@ -96,6 +123,10 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
   const savingsPercentage = Math.round((monthlySavings / (monthlyPrice * 12)) * 100)
   
   const visibleFeatures = showAllFeatures ? premiumFeatures : premiumFeatures.slice(0, 6)
+  const renewalDate = details?.currentPeriodEnd ? new Date(details.currentPeriodEnd) : null
+  const daysUntilRenewal = renewalDate
+    ? Math.max(0, Math.ceil((renewalDate.getTime() - new Date().getTime()) / (1000 * 3600 * 24)))
+    : null
 
   const handleUpgrade = async () => {
     setIsUpgrading(true)
@@ -129,6 +160,57 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
     }
   }
 
+  const handleUpdatePaymentMethod = async () => {
+    setIsUpdatingPayment(true)
+
+    try {
+      const res = await fetch("/api/payments/update-payment-method", { method: "POST" })
+
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.error || "Failed to create payment update link")
+      }
+
+      const { url } = await res.json()
+      if (url) {
+        window.location.href = url
+      } else {
+        toast.error("Dodo did not return a payment update link")
+      }
+    } catch (error) {
+      toast.error("Could not update payment method", {
+        description: error instanceof Error ? error.message : "Something went wrong",
+      })
+    } finally {
+      setIsUpdatingPayment(false)
+    }
+  }
+
+  const handleCancelSubscription = async () => {
+    const confirmed = window.confirm("Cancel your subscription at the end of the current billing period?")
+    if (!confirmed) return
+
+    setIsCancelling(true)
+
+    try {
+      const res = await fetch("/api/payments/cancel-subscription", { method: "POST" })
+
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.error || "Failed to cancel subscription")
+      }
+
+      toast.success("Subscription cancellation scheduled")
+      window.location.reload()
+    } catch (error) {
+      toast.error("Could not cancel subscription", {
+        description: error instanceof Error ? error.message : "Something went wrong",
+      })
+    } finally {
+      setIsCancelling(false)
+    }
+  }
+
   return (
     <div className="space-y-8">
       {/* Current Plan */}
@@ -145,7 +227,7 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
             </h3>
           </div>
           <Badge variant={isPremium ? "default" : "secondary"}>
-            {isPremium ? "Active" : "Current"}
+            {isPremium ? (details?.cancelAtPeriodEnd ? "Cancels soon" : "Active") : "Current"}
           </Badge>
         </div>
         
@@ -178,17 +260,28 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <Calendar className="h-4 w-4" />
-                  <span className="capitalize">Active subscription {details?.plan ? `(${details.plan})` : ""}</span>
+                  <span className="capitalize">
+                    {details?.status || "active"} subscription {details?.plan ? `(${details.plan})` : ""}
+                  </span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Receipt className="h-4 w-4" />
-                  <span>${details?.amountPaid || yearlyPrice}/{details?.plan === 'monthly' ? 'month' : 'year'}</span>
+                  <span>{formatMoney(details?.amount, details?.currency || "USD")}/{details?.billingInterval || details?.plan || "period"}</span>
                 </div>
               </div>
-              {details?.endDate && (
+              {renewalDate && (
                 <div className="flex items-center gap-2">
                   <TrendingUp className="h-4 w-4" />
-                  <span><strong className="text-foreground">{Math.max(0, Math.ceil((new Date(details.endDate).getTime() - new Date().getTime()) / (1000 * 3600 * 24)))} days left</strong> until renewal</span>
+                  <span>
+                    <strong className="text-foreground">{daysUntilRenewal} days left</strong>
+                    {details?.cancelAtPeriodEnd ? " until access ends" : " until renewal"}
+                  </span>
+                </div>
+              )}
+              {details?.cancelAtPeriodEnd && (
+                <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+                  <AlertTriangle className="h-4 w-4" />
+                  <span>Your subscription is scheduled to cancel at period end.</span>
                 </div>
               )}
             </div>
@@ -357,7 +450,10 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
                 <p className="font-medium text-sm">Update Payment Method</p>
                 <p className="text-xs text-muted-foreground">Managed by Dodo Payments</p>
               </div>
-              <Button variant="ghost" size="sm">Update</Button>
+              <Button variant="ghost" size="sm" onClick={handleUpdatePaymentMethod} disabled={isUpdatingPayment}>
+                {isUpdatingPayment ? <Loader2 className="h-4 w-4 animate-spin" /> : <CreditCard className="h-4 w-4" />}
+                <span className="ml-2">Update</span>
+              </Button>
             </div>
             
             <div className="flex items-center justify-between p-4 rounded-lg bg-destructive/5 border border-destructive/20">
@@ -367,8 +463,15 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
                   Your plan remains active until the billing period ends
                 </p>
               </div>
-              <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive">
-                Cancel
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                onClick={handleCancelSubscription}
+                disabled={isCancelling || details?.cancelAtPeriodEnd}
+              >
+                {isCancelling && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+                {details?.cancelAtPeriodEnd ? "Scheduled" : "Cancel"}
               </Button>
             </div>
           </section>
@@ -390,11 +493,11 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-border/50">
-                      {details.billingHistory.map((item: any, i: number) => (
-                        <tr key={i} className="hover:bg-muted/10 transition-colors">
-                          <td className="px-4 py-3">{new Date(item.date).toLocaleDateString()}</td>
-                          <td className="px-4 py-3 capitalize">{item.plan_type}</td>
-                          <td className="px-4 py-3 text-right">${item.amount}</td>
+                      {details.billingHistory.map((item) => (
+                        <tr key={item.id} className="hover:bg-muted/10 transition-colors">
+                          <td className="px-4 py-3">{item.paid_at ? new Date(item.paid_at).toLocaleDateString() : "Pending"}</td>
+                          <td className="px-4 py-3 capitalize">{item.plan_key || "Premium"}</td>
+                          <td className="px-4 py-3 text-right">{formatMoney(item.amount, item.currency || "USD")}</td>
                           <td className="px-4 py-3 text-center">
                             <Badge variant="outline" className="bg-green-500/10 text-green-500 border-green-200">
                               {item.status}

--- a/app/(dashboard)/settings/subscription/page.tsx
+++ b/app/(dashboard)/settings/subscription/page.tsx
@@ -1,37 +1,50 @@
-// app/(dashboard)/settings/subscription/page.tsx
-// Subscription settings page — fetches real plan from profiles table
-
 import { getUser } from "@/app/actions/auth"
 import { redirect } from "next/navigation"
 import { SubscriptionSection } from "./_components/subscription-section"
 import { createClient } from "@/lib/supabase/server"
 import { getAmplecenLoginUrl } from "@/lib/auth-redirect"
+import { RHYTHME_PRODUCT_KEY } from "@/lib/payments/dodo"
 
 export default async function SubscriptionPage() {
   const user = await getUser()
-  
+
   if (!user) {
-    redirect(getAmplecenLoginUrl('/settings/subscription'))
+    redirect(getAmplecenLoginUrl("/settings/subscription"))
   }
 
-  // Fetch real subscription status
   const supabase = await createClient()
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("is_premium, subscription_plan, subscription_amount_paid, subscription_end_date, billing_history")
-    .eq("id", user.id)
-    .single()
+  const { data: subscription } = await supabase
+    .from("account_subscriptions")
+    .select("plan_key, status, entitlement_active, amount, currency, billing_interval, current_period_end, cancel_at_period_end, provider_subscription_id")
+    .eq("user_id", user.id)
+    .eq("product_key", RHYTHME_PRODUCT_KEY)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
 
-  const currentPlan = profile?.is_premium ? "premium" : "starter"
+  const { data: billingHistory } = await supabase
+    .from("billing_events")
+    .select("id, provider_payment_id, plan_key, amount, currency, status, paid_at, receipt_url")
+    .eq("user_id", user.id)
+    .eq("product_key", RHYTHME_PRODUCT_KEY)
+    .order("paid_at", { ascending: false, nullsFirst: false })
+    .limit(6)
+
+  const currentPlan = subscription?.entitlement_active ? "premium" : "starter"
 
   return (
-    <SubscriptionSection 
+    <SubscriptionSection
       currentPlan={currentPlan}
       details={{
-        plan: profile?.subscription_plan,
-        amountPaid: profile?.subscription_amount_paid,
-        endDate: profile?.subscription_end_date,
-        billingHistory: profile?.billing_history,
+        plan: subscription?.plan_key,
+        status: subscription?.status,
+        amount: subscription?.amount,
+        currency: subscription?.currency,
+        billingInterval: subscription?.billing_interval,
+        currentPeriodEnd: subscription?.current_period_end,
+        cancelAtPeriodEnd: subscription?.cancel_at_period_end,
+        subscriptionId: subscription?.provider_subscription_id,
+        billingHistory: billingHistory ?? [],
       }}
     />
   )

--- a/app/actions/habits.ts
+++ b/app/actions/habits.ts
@@ -14,6 +14,7 @@ import {
   getPeriodLabel,
   computeUnifiedStreak,
 } from "@/lib/habit-helpers";
+import { canCreateHabit } from "@/app/actions/usage-limits";
 
 // === Authentication Helper ===
 async function getAuthenticatedUser() {
@@ -271,6 +272,13 @@ export async function createHabit(
 ): Promise<ActionResponse<Habit>> {
   try {
     const { supabase, user } = await getAuthenticatedUser();
+    const limit = await canCreateHabit();
+
+    if (!limit.allowed) {
+      return {
+        error: `Free accounts can track up to ${limit.limit} active habits. Upgrade to Premium for unlimited habits.`,
+      };
+    }
 
     const freq: HabitFrequency = input.frequency ?? 0;
     const targetCount = input.target_count ?? 1;

--- a/app/actions/settings.ts
+++ b/app/actions/settings.ts
@@ -81,6 +81,20 @@ export async function updateUserProfile(formData: FormData): Promise<SettingsAct
     return { success: false, error: error.message }
   }
 
+  const { data: { user } } = await supabase.auth.getUser()
+  if (user) {
+    await supabase
+      .from("profiles")
+      .upsert({
+        id: user.id,
+        email: user.email,
+        full_name: displayName.trim(),
+        avatar_url: user.user_metadata?.avatar_url || user.user_metadata?.picture || null,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: "id" })
+  }
+
+  revalidatePath("/settings/profile")
   revalidatePath("/settings/account")
   revalidatePath("/dashboard")
   

--- a/app/actions/subscription.ts
+++ b/app/actions/subscription.ts
@@ -2,11 +2,13 @@
 'use server'
 
 import { createClient } from '@/lib/supabase/server'
+import { RHYTHME_PRODUCT_KEY } from '@/lib/payments/dodo'
 
 export interface SubscriptionStatus {
   isPremium: boolean
   subscriptionStatus: string
   subscriptionId: string | null
+  cancelAtPeriodEnd?: boolean
 }
 
 /**
@@ -30,19 +32,23 @@ export async function getSubscriptionStatus(): Promise<SubscriptionStatus> {
   }
 
   const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('is_premium, subscription_status, subscription_id')
-    .eq('id', user.id)
-    .single()
+    .from('account_subscriptions')
+    .select('entitlement_active, status, provider_subscription_id, cancel_at_period_end')
+    .eq('user_id', user.id)
+    .eq('product_key', RHYTHME_PRODUCT_KEY)
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
 
-  // If no profile exists, create one with defaults
+  // If no profile exists, create one with defaults for the central account table.
   if (profileError || !profile) {
     await supabase
       .from('profiles')
       .upsert({
         id: user.id,
-        is_premium: false,
-        subscription_status: 'inactive',
+        email: user.email,
+        full_name: user.user_metadata?.full_name || user.user_metadata?.name || null,
+        avatar_url: user.user_metadata?.avatar_url || user.user_metadata?.picture || null,
       }, { onConflict: 'id' })
 
     return {
@@ -53,8 +59,14 @@ export async function getSubscriptionStatus(): Promise<SubscriptionStatus> {
   }
 
   return {
-    isPremium: profile.is_premium ?? false,
-    subscriptionStatus: profile.subscription_status ?? 'inactive',
-    subscriptionId: profile.subscription_id ?? null,
+    isPremium: profile.entitlement_active ?? false,
+    subscriptionStatus: profile.status ?? 'inactive',
+    subscriptionId: profile.provider_subscription_id ?? null,
+    cancelAtPeriodEnd: profile.cancel_at_period_end ?? false,
   }
+}
+
+export async function isCurrentUserPremium(): Promise<boolean> {
+  const status = await getSubscriptionStatus()
+  return status.isPremium
 }

--- a/app/actions/usage-limits.ts
+++ b/app/actions/usage-limits.ts
@@ -4,6 +4,7 @@
 'use server'
 
 import { createClient } from '@/lib/supabase/server'
+import { isCurrentUserPremium } from '@/app/actions/subscription'
 
 /**
  * Check if the user can create a journal entry today.
@@ -15,14 +16,7 @@ export async function canCreateJournal(): Promise<{ allowed: boolean; count: num
 
   if (!user) return { allowed: false, count: 0, limit: 1 }
 
-  // Check if premium
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('is_premium')
-    .eq('id', user.id)
-    .single()
-
-  if (profile?.is_premium) return { allowed: true, count: 0, limit: Infinity }
+  if (await isCurrentUserPremium()) return { allowed: true, count: 0, limit: Infinity }
 
   // Count today's journals
   const today = new Date()
@@ -50,14 +44,7 @@ export async function canCreateTask(): Promise<{ allowed: boolean; count: number
 
   if (!user) return { allowed: false, count: 0, limit: 10 }
 
-  // Check if premium
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('is_premium')
-    .eq('id', user.id)
-    .single()
-
-  if (profile?.is_premium) return { allowed: true, count: 0, limit: Infinity }
+  if (await isCurrentUserPremium()) return { allowed: true, count: 0, limit: Infinity }
 
   // Count today's tasks
   const today = new Date()
@@ -77,22 +64,15 @@ export async function canCreateTask(): Promise<{ allowed: boolean; count: number
 
 /**
  * Check if the user can create a habit.
- * Free users: 5 habits total (active). Premium users: unlimited.
+ * Free users: 3 active habits total. Premium users: unlimited.
  */
 export async function canCreateHabit(): Promise<{ allowed: boolean; count: number; limit: number }> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 
-  if (!user) return { allowed: false, count: 0, limit: 5 }
+  if (!user) return { allowed: false, count: 0, limit: 3 }
 
-  // Check if premium
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('is_premium')
-    .eq('id', user.id)
-    .single()
-
-  if (profile?.is_premium) return { allowed: true, count: 0, limit: Infinity }
+  if (await isCurrentUserPremium()) return { allowed: true, count: 0, limit: Infinity }
 
   // Count total active habits
   const { count } = await supabase
@@ -102,5 +82,5 @@ export async function canCreateHabit(): Promise<{ allowed: boolean; count: numbe
     .eq('is_active', true)
 
   const currentCount = count ?? 0
-  return { allowed: currentCount < 5, count: currentCount, limit: 5 }
+  return { allowed: currentCount < 3, count: currentCount, limit: 3 }
 }

--- a/app/api/payments/cancel-subscription/route.ts
+++ b/app/api/payments/cancel-subscription/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { getAdminClient } from "@/lib/supabase/admin"
+import { getDodoClient, RHYTHME_PRODUCT_KEY } from "@/lib/payments/dodo"
+
+export async function POST() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { data: subscription, error } = await supabase
+    .from("account_subscriptions")
+    .select("id, provider_subscription_id")
+    .eq("user_id", user.id)
+    .eq("product_key", RHYTHME_PRODUCT_KEY)
+    .eq("provider", "dodo")
+    .eq("entitlement_active", true)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !subscription?.provider_subscription_id) {
+    return NextResponse.json({ error: "No active subscription found" }, { status: 404 })
+  }
+
+  try {
+    const updated = await getDodoClient().subscriptions.update(subscription.provider_subscription_id, {
+      cancel_at_next_billing_date: true,
+      cancel_reason: "cancelled_by_customer",
+    })
+
+    await getAdminClient()
+      .from("account_subscriptions")
+      .update({
+        status: updated.status,
+        entitlement_active: updated.status === "active" || updated.status === "on_hold",
+        cancel_at_period_end: updated.cancel_at_next_billing_date,
+        canceled_at: updated.cancelled_at,
+        raw_payload: updated,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", subscription.id)
+
+    return NextResponse.json({
+      status: updated.status,
+      cancel_at_period_end: updated.cancel_at_next_billing_date,
+      current_period_end: updated.next_billing_date || updated.expires_at,
+    })
+  } catch (error) {
+    console.error("Cancel subscription error:", error)
+    return NextResponse.json({ error: "Failed to cancel subscription" }, { status: 500 })
+  }
+}

--- a/app/api/payments/create-subscription/route.ts
+++ b/app/api/payments/create-subscription/route.ts
@@ -1,18 +1,8 @@
 // app/api/payments/create-subscription/route.ts
 import { NextResponse } from 'next/server';
-import DodoPayments from 'dodopayments';
 import { createClient } from '@/lib/supabase/server';
 import { getAdminClient } from '@/lib/supabase/admin';
-
-const dodopayments = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: 'test_mode',
-});
-
-const PRODUCT_IDS = {
-  monthly: process.env.DODO_MONTHLY_SUBSCRIPTION_ID,
-  yearly: process.env.DODO_YEARLY_SUBSCRIPTION_ID,
-} as const;
+import { DODO_PRODUCT_IDS, getDodoClient, RHYTHME_PRODUCT_KEY, type BillingPlan } from '@/lib/payments/dodo';
 
 export async function POST(request: Request) {
   const supabase = await createClient();
@@ -24,20 +14,21 @@ export async function POST(request: Request) {
 
   try {
     const body = await request.json();
-    const plan = body.plan as 'monthly' | 'yearly';
+    const plan = body.plan as BillingPlan;
 
-    if (!plan || !PRODUCT_IDS[plan]) {
+    if (!plan || !DODO_PRODUCT_IDS[plan]) {
       return NextResponse.json({ error: 'Invalid plan or missing product id.' }, { status: 400 });
     }
 
     // Get app URL for redirect
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
     const returnUrl = `${appUrl}/settings/subscription`;
+    const dodopayments = getDodoClient();
 
     const session = await dodopayments.checkoutSessions.create({
       product_cart: [
         {
-          product_id: PRODUCT_IDS[plan]!,
+          product_id: DODO_PRODUCT_IDS[plan]!,
           quantity: 1,
         },
       ],
@@ -48,18 +39,38 @@ export async function POST(request: Request) {
       },
       metadata: {
         user_id: user.id,
+        product_key: RHYTHME_PRODUCT_KEY,
+        plan_key: plan,
       },
     });
 
     const adminSupabase = getAdminClient();
 
-    // Initial status, waiting for webhook
     await adminSupabase
       .from('profiles')
-      .update({
-        subscription_status: 'created',
-      })
-      .eq('id', user.id);
+      .upsert({
+        id: user.id,
+        email: user.email,
+        full_name: user.user_metadata?.full_name || user.user_metadata?.name || null,
+        avatar_url: user.user_metadata?.avatar_url || user.user_metadata?.picture || null,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'id' });
+
+    // The subscription id is delivered by webhook after checkout completes.
+    await adminSupabase
+      .from('account_subscriptions')
+      .upsert({
+        user_id: user.id,
+        product_key: RHYTHME_PRODUCT_KEY,
+        provider: 'dodo',
+        provider_subscription_id: `checkout:${session.session_id}`,
+        provider_product_id: DODO_PRODUCT_IDS[plan],
+        plan_key: plan,
+        status: 'pending',
+        entitlement_active: false,
+        raw_payload: session,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'provider,provider_subscription_id' });
 
     return NextResponse.json({
       checkout_url: session.checkout_url,

--- a/app/api/payments/update-payment-method/route.ts
+++ b/app/api/payments/update-payment-method/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { getDodoClient, RHYTHME_PRODUCT_KEY } from "@/lib/payments/dodo"
+
+export async function POST() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { data: subscription, error } = await supabase
+    .from("account_subscriptions")
+    .select("provider_subscription_id")
+    .eq("user_id", user.id)
+    .eq("product_key", RHYTHME_PRODUCT_KEY)
+    .eq("provider", "dodo")
+    .eq("entitlement_active", true)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !subscription?.provider_subscription_id) {
+    return NextResponse.json({ error: "No active subscription found" }, { status: 404 })
+  }
+
+  try {
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"
+    const response = await getDodoClient().subscriptions.updatePaymentMethod(
+      subscription.provider_subscription_id,
+      {
+        type: "new",
+        return_url: `${appUrl}/settings/subscription`,
+      },
+    )
+
+    if (!response.payment_link) {
+      return NextResponse.json({ error: "Dodo did not return a payment update link" }, { status: 502 })
+    }
+
+    return NextResponse.json({ url: response.payment_link })
+  } catch (error) {
+    console.error("Update payment method error:", error)
+    return NextResponse.json({ error: "Failed to create payment method update link" }, { status: 500 })
+  }
+}

--- a/app/api/payments/webhook/route.ts
+++ b/app/api/payments/webhook/route.ts
@@ -1,91 +1,183 @@
-// app/api/payments/webhook/route.ts
-import { NextResponse } from 'next/server';
-import DodoPayments from 'dodopayments';
-import { getAdminClient } from '@/lib/supabase/admin';
+import { NextResponse } from "next/server"
+import type { UnwrapWebhookEvent } from "dodopayments/resources/webhooks"
+import { getAdminClient } from "@/lib/supabase/admin"
+import { getDodoClient, isEntitledStatus, planFromProductId, RHYTHME_PRODUCT_KEY } from "@/lib/payments/dodo"
 
-const dodopayments = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: 'test_mode',
-});
+const webhookSecret = process.env.DODO_WEBHOOK_SECRET
 
-const webhookSecret = process.env.DODO_WEBHOOK_SECRET;
+function amountFromSmallestUnit(amount?: number | null) {
+  if (typeof amount !== "number") return null
+  return amount / 100
+}
+
+type DodoMetadata = Record<string, string | undefined>
+type DodoCustomer = {
+  customer_id?: string
+  email?: string
+  metadata?: DodoMetadata
+}
+type DodoWebhookData = {
+  metadata?: DodoMetadata
+  customer?: DodoCustomer
+  subscription_id?: string | null
+  customer_id?: string | null
+}
+
+async function findUserId(supabase: ReturnType<typeof getAdminClient>, data: DodoWebhookData) {
+  const metadataUserId = data?.metadata?.user_id || data?.customer?.metadata?.user_id
+  if (metadataUserId) return metadataUserId as string
+
+  const subscriptionId = data?.subscription_id
+  if (subscriptionId) {
+    const { data: subscription } = await supabase
+      .from("account_subscriptions")
+      .select("user_id")
+      .eq("provider", "dodo")
+      .eq("provider_subscription_id", subscriptionId)
+      .maybeSingle()
+
+    if (subscription?.user_id) return subscription.user_id as string
+  }
+
+  const customerId = data?.customer_id || data?.customer?.customer_id
+  if (customerId) {
+    const { data: subscription } = await supabase
+      .from("account_subscriptions")
+      .select("user_id")
+      .eq("provider", "dodo")
+      .eq("provider_customer_id", customerId)
+      .order("updated_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (subscription?.user_id) return subscription.user_id as string
+  }
+
+  const email = data?.customer?.email
+  if (email) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id")
+      .eq("email", email)
+      .maybeSingle()
+
+    if (profile?.id) return profile.id as string
+  }
+
+  return null
+}
 
 export async function POST(request: Request) {
-  const body = await request.text();
-  const signature = request.headers.get('webhook-signature');
-  const headers = Object.fromEntries(request.headers.entries()) as Record<string, string>;
+  const body = await request.text()
+  const headers = Object.fromEntries(request.headers.entries()) as Record<string, string>
 
-  if (!signature || !webhookSecret) {
-    return NextResponse.json({ error: 'Missing signature or webhook secret' }, { status: 400 });
+  if (!webhookSecret) {
+    return NextResponse.json({ error: "Missing webhook secret" }, { status: 400 })
   }
 
-  let event: any;
+  let event: UnwrapWebhookEvent
 
   try {
-    // Verify the webhook signature using the SDK
-    event = dodopayments.webhooks.unwrap(body, { headers, key: webhookSecret });
-  } catch (err: any) {
-    console.error('Webhook signature verification failed.', err.message);
-    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+    event = getDodoClient().webhooks.unwrap(body, { headers, key: webhookSecret })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    console.error("Webhook signature verification failed.", message)
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 })
   }
 
-  const supabase = getAdminClient();
+  const supabase = getAdminClient()
 
   try {
     switch (event.type) {
-      case 'subscription.active':
-      case 'subscription.renewed': {
-        const subscription = event.data;
-        const customerId = subscription.customer_id;
-        const email = subscription.customer?.email; // Optional, might need to look up by email
+      case "subscription.active":
+      case "subscription.renewed":
+      case "subscription.updated":
+      case "subscription.plan_changed":
+      case "subscription.on_hold":
+      case "subscription.cancelled":
+      case "subscription.failed":
+      case "subscription.expired": {
+        const subscription = event.data
+        const userId = await findUserId(supabase, subscription)
 
-        const userId = subscription.metadata?.user_id;
-
-        if (userId) {
-          await supabase
-            .from('profiles')
-            .update({
-              subscription_id: subscription.subscription_id,
-              subscription_status: subscription.status,
-              is_premium: true,
-            })
-            .eq('id', userId);
-        } else if (email) {
-          // Fallback if metadata is missing
-          const { data: userData } = await supabase.from('profiles').select('id').eq('email', email).single();
-          if (userData?.id) {
-            await supabase
-              .from('profiles')
-              .update({
-                subscription_id: subscription.subscription_id,
-                subscription_status: subscription.status,
-                is_premium: true,
-              })
-              .eq('id', userData.id);
-          }
-        }
-        break;
-      }
-      case 'subscription.cancelled':
-      case 'subscription.failed':
-      case 'subscription.expired': {
-        const subscription = event.data;
-        await supabase
-          .from('profiles')
-          .update({
-            subscription_status: subscription.status,
-            is_premium: false,
+        if (!userId) {
+          console.warn("Dodo subscription webhook missing user mapping", {
+            type: event.type,
+            subscription_id: subscription.subscription_id,
           })
-          .eq('subscription_id', subscription.subscription_id);
-        break;
+          break
+        }
+
+        const status = subscription.status ?? event.type.replace("subscription.", "")
+
+        await supabase
+          .from("account_subscriptions")
+          .upsert({
+            user_id: userId,
+            product_key: subscription.metadata?.product_key || RHYTHME_PRODUCT_KEY,
+            provider: "dodo",
+            provider_customer_id: subscription.customer?.customer_id,
+            provider_subscription_id: subscription.subscription_id,
+            provider_product_id: subscription.product_id,
+            plan_key: subscription.metadata?.plan_key || planFromProductId(subscription.product_id),
+            status,
+            entitlement_active: isEntitledStatus(status) && !subscription.cancelled_at,
+            amount: amountFromSmallestUnit(subscription.recurring_pre_tax_amount),
+            currency: subscription.currency,
+            billing_interval: subscription.payment_frequency_interval,
+            current_period_start: subscription.previous_billing_date,
+            current_period_end: subscription.next_billing_date || subscription.expires_at,
+            cancel_at_period_end: subscription.cancel_at_next_billing_date ?? false,
+            canceled_at: subscription.cancelled_at,
+            raw_payload: subscription,
+            updated_at: new Date().toISOString(),
+          }, { onConflict: "provider,provider_subscription_id" })
+
+        break
       }
+
+      case "payment.succeeded":
+      case "payment.failed":
+      case "payment.cancelled":
+      case "payment.processing": {
+        const payment = event.data
+        const userId = await findUserId(supabase, payment)
+
+        if (!userId) {
+          console.warn("Dodo payment webhook missing user mapping", {
+            type: event.type,
+            payment_id: payment.payment_id,
+          })
+          break
+        }
+
+        await supabase
+          .from("billing_events")
+          .upsert({
+            user_id: userId,
+            product_key: payment.metadata?.product_key || RHYTHME_PRODUCT_KEY,
+            provider: "dodo",
+            provider_payment_id: payment.payment_id,
+            provider_subscription_id: payment.subscription_id,
+            plan_key: payment.metadata?.plan_key,
+            amount: amountFromSmallestUnit(payment.total_amount),
+            currency: payment.currency,
+            status: payment.status || event.type.replace("payment.", ""),
+            paid_at: payment.created_at,
+            receipt_url: payment.invoice_url,
+            raw_payload: payment,
+          }, { onConflict: "provider,provider_payment_id" })
+
+        break
+      }
+
       default:
-        console.log(`Unhandled event type ${event.type}`);
+        console.log(`Unhandled Dodo event type ${event.type}`)
     }
 
-    return NextResponse.json({ received: true });
+    return NextResponse.json({ received: true })
   } catch (error) {
-    console.error('Webhook handler error:', error);
-    return NextResponse.json({ error: 'Webhook handler failed' }, { status: 500 });
+    console.error("Webhook handler error:", error)
+    return NextResponse.json({ error: "Webhook handler failed" }, { status: 500 })
   }
 }

--- a/lib/payments/dodo.ts
+++ b/lib/payments/dodo.ts
@@ -1,0 +1,28 @@
+import DodoPayments from "dodopayments"
+
+export const RHYTHME_PRODUCT_KEY = "rhythme"
+
+export const DODO_PRODUCT_IDS = {
+  monthly: process.env.DODO_MONTHLY_SUBSCRIPTION_ID,
+  yearly: process.env.DODO_YEARLY_SUBSCRIPTION_ID,
+} as const
+
+export type BillingPlan = keyof typeof DODO_PRODUCT_IDS
+
+export function getDodoClient() {
+  return new DodoPayments({
+    bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+    environment: process.env.DODO_PAYMENTS_ENVIRONMENT === "live_mode" ? "live_mode" : "test_mode",
+  })
+}
+
+export function planFromProductId(productId?: string | null): BillingPlan | null {
+  if (!productId) return null
+  if (productId === DODO_PRODUCT_IDS.monthly) return "monthly"
+  if (productId === DODO_PRODUCT_IDS.yearly) return "yearly"
+  return null
+}
+
+export function isEntitledStatus(status?: string | null) {
+  return status === "active" || status === "on_hold"
+}

--- a/supabase/migrations/20260424_account_billing_normalization.sql
+++ b/supabase/migrations/20260424_account_billing_normalization.sql
@@ -1,0 +1,183 @@
+-- Normalize account identity and product billing.
+-- profiles belongs to Amplecen ID. Product subscriptions belong to product-aware tables.
+
+alter table public.profiles
+  add column if not exists email text,
+  add column if not exists full_name text,
+  add column if not exists avatar_url text,
+  add column if not exists account_status text not null default 'active',
+  add column if not exists updated_at timestamp with time zone not null default now(),
+  add column if not exists metadata jsonb not null default '{}'::jsonb;
+
+alter table public.profiles
+  add constraint profiles_account_status_check
+  check (account_status in ('active', 'disabled', 'pending_deletion'))
+  not valid;
+
+alter table public.profiles validate constraint profiles_account_status_check;
+
+create table if not exists public.account_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on update cascade on delete cascade,
+  product_key text not null default 'rhythme',
+  provider text not null default 'dodo',
+  provider_customer_id text,
+  provider_subscription_id text not null,
+  provider_product_id text,
+  plan_key text,
+  status text not null default 'pending',
+  entitlement_active boolean not null default false,
+  amount numeric,
+  currency text,
+  billing_interval text,
+  current_period_start timestamp with time zone,
+  current_period_end timestamp with time zone,
+  cancel_at_period_end boolean not null default false,
+  canceled_at timestamp with time zone,
+  raw_payload jsonb not null default '{}'::jsonb,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint account_subscriptions_provider_subscription_unique unique (provider, provider_subscription_id),
+  constraint account_subscriptions_product_provider_subscription_unique unique (product_key, provider, provider_subscription_id)
+);
+
+create index if not exists account_subscriptions_user_product_idx
+  on public.account_subscriptions (user_id, product_key);
+
+create index if not exists account_subscriptions_entitlement_idx
+  on public.account_subscriptions (user_id, product_key, entitlement_active)
+  where entitlement_active = true;
+
+create table if not exists public.billing_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on update cascade on delete cascade,
+  product_key text not null default 'rhythme',
+  provider text not null default 'dodo',
+  provider_payment_id text,
+  provider_subscription_id text,
+  plan_key text,
+  amount numeric,
+  currency text,
+  status text not null,
+  paid_at timestamp with time zone,
+  receipt_url text,
+  raw_payload jsonb not null default '{}'::jsonb,
+  created_at timestamp with time zone not null default now(),
+  constraint billing_events_provider_payment_unique unique (provider, provider_payment_id)
+);
+
+create index if not exists billing_events_user_product_paid_at_idx
+  on public.billing_events (user_id, product_key, paid_at desc nulls last);
+
+-- Migrate the old profile-level subscription state before dropping legacy columns.
+insert into public.account_subscriptions (
+  user_id,
+  product_key,
+  provider,
+  provider_subscription_id,
+  plan_key,
+  status,
+  entitlement_active,
+  amount,
+  billing_interval,
+  current_period_start,
+  current_period_end,
+  raw_payload
+)
+select
+  p.id,
+  'rhythme',
+  'dodo',
+  p.subscription_id,
+  p.subscription_plan,
+  coalesce(p.subscription_status, 'pending'),
+  coalesce(p.is_premium, false),
+  p.subscription_amount_paid,
+  p.subscription_plan,
+  p.subscription_start_date,
+  p.subscription_end_date,
+  jsonb_build_object(
+    'migrated_from', 'profiles',
+    'legacy_subscription_id', p.subscription_id,
+    'legacy_razorpay_subscription_id', p.razorpay_subscription_id
+  )
+from public.profiles p
+where p.subscription_id is not null
+on conflict (provider, provider_subscription_id) do update set
+  plan_key = excluded.plan_key,
+  status = excluded.status,
+  entitlement_active = excluded.entitlement_active,
+  amount = excluded.amount,
+  billing_interval = excluded.billing_interval,
+  current_period_start = excluded.current_period_start,
+  current_period_end = excluded.current_period_end,
+  updated_at = now();
+
+insert into public.billing_events (
+  id,
+  user_id,
+  product_key,
+  provider,
+  provider_payment_id,
+  plan_key,
+  amount,
+  status,
+  paid_at,
+  raw_payload
+)
+select
+  coalesce((item->>'id')::uuid, gen_random_uuid()),
+  p.id,
+  'rhythme',
+  'dodo',
+  item->>'payment_id',
+  item->>'plan_type',
+  nullif(item->>'amount', '')::numeric,
+  coalesce(item->>'status', 'paid'),
+  nullif(item->>'date', '')::timestamp with time zone,
+  item
+from public.profiles p
+cross join lateral jsonb_array_elements(coalesce(p.billing_history, '[]'::jsonb)) item
+on conflict (provider, provider_payment_id) do update set
+  status = excluded.status,
+  paid_at = excluded.paid_at,
+  raw_payload = excluded.raw_payload;
+
+alter table public.account_subscriptions enable row level security;
+alter table public.billing_events enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'account_subscriptions'
+      and policyname = 'Users can view their own account subscriptions'
+  ) then
+    create policy "Users can view their own account subscriptions"
+      on public.account_subscriptions for select
+      using (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'billing_events'
+      and policyname = 'Users can view their own billing events'
+  ) then
+    create policy "Users can view their own billing events"
+      on public.billing_events for select
+      using (auth.uid() = user_id);
+  end if;
+end $$;
+
+alter table public.profiles
+  drop column if exists razorpay_subscription_id,
+  drop column if exists subscription_status,
+  drop column if exists subscription_plan,
+  drop column if exists subscription_amount_paid,
+  drop column if exists subscription_start_date,
+  drop column if exists subscription_end_date,
+  drop column if exists billing_history,
+  drop column if exists subscription_id,
+  drop column if exists is_premium;

--- a/supabase/migrations/20260424_enforce_free_habit_limit.sql
+++ b/supabase/migrations/20260424_enforce_free_habit_limit.sql
@@ -1,0 +1,54 @@
+-- Enforce the Rhythme free-tier habit limit at the database boundary.
+-- App/UI checks are helpful, but this prevents direct inserts from bypassing the gate.
+
+create or replace function public.enforce_rhythme_habit_limit()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  active_habit_count integer;
+  has_premium boolean;
+begin
+  if coalesce(new.is_active, true) is not true then
+    return new;
+  end if;
+
+  select exists (
+    select 1
+    from public.account_subscriptions s
+    where s.user_id = new.user_id
+      and s.product_key = 'rhythme'
+      and s.entitlement_active = true
+      and s.status in ('active', 'on_hold')
+  )
+  into has_premium;
+
+  if has_premium then
+    return new;
+  end if;
+
+  select count(*)
+  from public.habits h
+  where h.user_id = new.user_id
+    and h.is_active = true
+    and (tg_op = 'INSERT' or h.habit_id <> new.habit_id)
+  into active_habit_count;
+
+  if active_habit_count >= 3 then
+    raise exception 'Free accounts can track up to 3 active habits. Upgrade to Premium for unlimited habits.'
+      using errcode = 'P0001';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists enforce_rhythme_habit_limit_trigger on public.habits;
+
+create trigger enforce_rhythme_habit_limit_trigger
+before insert or update of is_active, user_id
+on public.habits
+for each row
+execute function public.enforce_rhythme_habit_limit();


### PR DESCRIPTION
Replace legacy Razorpay/profile-level billing with a Dodo-based, product-aware billing model and normalize account billing data.

- Add lib/payments/dodo.ts wrapper and constants (RHYTHME_PRODUCT_KEY, product ids, client helper, helpers).
- Introduce account_subscriptions and billing_events tables + RLS in new DB migration; migrate legacy profile subscription/billing_history into the new tables.
- Add DB trigger migration to enforce free-tier habit limit at the database level (3 active habits for free tier).
- Add server API routes for payments: create-subscription, update-payment-method, cancel-subscription, and enhanced webhook handler to sync Dodo subscription/payment events into account_subscriptions and billing_events.
- Update server actions to query normalized tables: subscription status, billing history, and premium checks (isCurrentUserPremium) and wire them into usage limits.
- Enforce habit creation limits in UI/server: canCreateHabit updated and createHabit action checks the limit before inserting.
- Update settings/profile/subscription/billing-history pages and components to read from new tables and display Dodo-managed flows (payment links, receipt links, formatted amounts, cancel/update flows, status/renewal messaging).
- Misc: profile upsert on settings update, revalidation of profile/account/dashboard paths after profile change, small UI/formatting improvements.

This change centralizes billing data, migrates legacy profile billing info, and integrates Dodo as the payments provider while adding server- and DB-side protections for free-tier limits.