### PR TITLE
Add mood tracking feature

### DIFF
--- a/app/(dashboard)/dashboard/mood/history/mood-history-client.tsx
+++ b/app/(dashboard)/dashboard/mood/history/mood-history-client.tsx
@@ -1,0 +1,579 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import Link from "next/link"
+import { motion, AnimatePresence } from "framer-motion"
+import {
+  CalendarDays,
+  ChevronLeft,
+  ChevronRight,
+  HeartPulse,
+  PencilLine,
+  X,
+} from "lucide-react"
+import { SiteHeader } from "@/components/site-header"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  useMoodLogs,
+  useCreateMoodLog,
+  useUpdateMoodLog,
+} from "@/hooks/use-mood-logs"
+import { canCreateMoodLog } from "@/app/actions/usage-limits"
+import { PremiumGateModal } from "@/components/premium-gate-modal"
+import { MOOD_SCALE, formatMoodScore, getMoodOption } from "@/lib/mood"
+import { cn } from "@/lib/utils"
+import type { MoodLog } from "@/types/database"
+import { toast } from "sonner"
+
+/* ── Helpers ──────────────────────────────────────────────── */
+
+const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+function toDateKey(d: Date) {
+  return d.toISOString().split("T")[0]
+}
+
+function daysInMonth(year: number, month: number) {
+  return new Date(year, month + 1, 0).getDate()
+}
+
+/** Monday = 0 … Sunday = 6 */
+function startDayOfWeek(year: number, month: number) {
+  const d = new Date(year, month, 1).getDay()
+  return d === 0 ? 6 : d - 1
+}
+
+function formatMonthYear(year: number, month: number) {
+  return new Date(year, month).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  })
+}
+
+function formatFullDate(dateStr: string) {
+  return new Date(`${dateStr}T12:00:00`).toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+function moodColor(score: number): string {
+  const opt = getMoodOption(score)
+  return opt?.accent ?? "bg-muted"
+}
+
+function moodSoftColor(score: number): string {
+  const opt = getMoodOption(score)
+  return opt?.softAccent ?? "bg-muted/30"
+}
+
+/* ── Calendar Heatmap ─────────────────────────────────────── */
+
+function CalendarHeatmap({
+  year,
+  month,
+  logMap,
+  onDayClick,
+  selectedDay,
+}: {
+  year: number
+  month: number
+  logMap: Map<string, MoodLog>
+  onDayClick: (dateKey: string) => void
+  selectedDay: string | null
+}) {
+  const totalDays = daysInMonth(year, month)
+  const offset = startDayOfWeek(year, month)
+  const todayKey = toDateKey(new Date())
+
+  const cells: (number | null)[] = []
+  for (let i = 0; i < offset; i++) cells.push(null)
+  for (let d = 1; d <= totalDays; d++) cells.push(d)
+
+  return (
+    <div className="space-y-2">
+      {/* Weekday header */}
+      <div className="grid grid-cols-7 gap-1">
+        {WEEKDAY_LABELS.map((label) => (
+          <div
+            key={label}
+            className="text-center text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60"
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Day grid */}
+      <div className="grid grid-cols-7 gap-1">
+        {cells.map((day, i) => {
+          if (day === null) {
+            return <div key={`empty-${i}`} className="aspect-square" />
+          }
+
+          const dateKey = `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`
+          const log = logMap.get(dateKey)
+          const score = log ? Number(log.mood_score) : null
+          const isToday = dateKey === todayKey
+          const isSelected = dateKey === selectedDay
+          const isFuture = dateKey > todayKey
+
+          return (
+            <button
+              key={dateKey}
+              type="button"
+              onClick={() => !isFuture && onDayClick(dateKey)}
+              disabled={isFuture}
+              className={cn(
+                "relative flex flex-col items-center justify-center rounded-lg aspect-square text-xs transition-all duration-150",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                isFuture && "opacity-30 cursor-default",
+                isSelected
+                  ? "ring-2 ring-primary ring-offset-1 ring-offset-background shadow-sm"
+                  : "hover:bg-muted/30",
+                score !== null ? moodSoftColor(score) : "bg-transparent"
+              )}
+            >
+              {/* Mood dot */}
+              {score !== null && (
+                <span
+                  className={cn(
+                    "absolute top-1 right-1 h-1.5 w-1.5 rounded-full",
+                    moodColor(score)
+                  )}
+                />
+              )}
+
+              <span
+                className={cn(
+                  "tabular-nums font-medium",
+                  isToday && "text-primary font-bold",
+                  score !== null
+                    ? "text-foreground"
+                    : "text-muted-foreground/60"
+                )}
+              >
+                {day}
+              </span>
+
+              {/* Emoji for logged days */}
+              {score !== null && (
+                <span className="text-[10px] leading-none mt-0.5">
+                  {getMoodOption(score)?.emoji}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/* ── Day detail panel ─────────────────────────────────────── */
+
+function DayDetail({
+  dateKey,
+  log,
+  onClose,
+  onSave,
+  isSaving,
+}: {
+  dateKey: string
+  log: MoodLog | null
+  onClose: () => void
+  onSave: (score: number, note: string) => void
+  isSaving: boolean
+}) {
+  const [score, setScore] = useState<number | null>(
+    log ? Number(log.mood_score) : null
+  )
+  const [note, setNote] = useState(log?.note ?? "")
+  const mood = score !== null ? getMoodOption(score) : null
+
+  function handleSave() {
+    if (score === null) return
+    onSave(score, note)
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 8 }}
+      className="rounded-2xl border border-border/50 bg-background p-5 shadow-sm"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-sm font-semibold">{formatFullDate(dateKey)}</h3>
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onClose}>
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Mood selector row */}
+      <div className="mb-4 flex flex-wrap gap-1.5">
+        {MOOD_SCALE.map((opt) => {
+          const active = score === opt.value
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setScore(opt.value)}
+              className={cn(
+                "flex flex-col items-center rounded-xl border-2 px-2 py-1.5 transition-all",
+                "min-w-[48px]",
+                active
+                  ? `${opt.softAccent} ${opt.border} shadow-sm`
+                  : "border-transparent hover:bg-muted/20"
+              )}
+            >
+              <span className="text-lg leading-none">{opt.emoji}</span>
+              <span
+                className={cn(
+                  "mt-0.5 text-[9px] font-medium",
+                  active ? opt.text : "text-muted-foreground"
+                )}
+              >
+                {formatMoodScore(opt.value)}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Selected mood label */}
+      {mood && (
+        <p className="mb-3 text-xs text-muted-foreground">
+          {mood.emoji} {mood.label} — {mood.description}
+        </p>
+      )}
+
+      {/* Note */}
+      <Textarea
+        placeholder="Add a note about this day..."
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        rows={3}
+        className="mb-3 resize-none bg-muted/10"
+      />
+
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={handleSave} disabled={score === null || isSaving}>
+          <PencilLine className="mr-1.5 h-3.5 w-3.5" />
+          {log ? "Update" : "Save"}
+        </Button>
+      </div>
+    </motion.div>
+  )
+}
+
+/* ── Entry list ───────────────────────────────────────────── */
+
+function EntryList({
+  logs,
+  onEntryClick,
+}: {
+  logs: MoodLog[]
+  onEntryClick: (dateKey: string) => void
+}) {
+  if (logs.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-border/50 bg-muted/5 px-6 py-10 text-center">
+        <CalendarDays className="mx-auto mb-2 h-6 w-6 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">
+          No mood entries this month yet.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {logs.map((log) => {
+        const mood = getMoodOption(Number(log.mood_score))
+        return (
+          <button
+            key={log.id}
+            type="button"
+            onClick={() => onEntryClick(log.logged_at)}
+            className={cn(
+              "flex w-full items-start gap-3 rounded-xl border border-border/40 bg-background p-3.5 text-left transition-colors",
+              "hover:border-border hover:bg-muted/10"
+            )}
+          >
+            {/* Emoji */}
+            <span className="mt-0.5 text-xl leading-none">{mood?.emoji ?? "·"}</span>
+
+            {/* Content */}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-baseline gap-2">
+                <span className="text-sm font-medium">
+                  {new Date(`${log.logged_at}T12:00:00`).toLocaleDateString("en-US", {
+                    weekday: "short",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    "rounded-full text-[10px] px-2 py-0",
+                    mood?.softAccent,
+                    mood?.text,
+                    mood?.border
+                  )}
+                >
+                  {formatMoodScore(Number(log.mood_score))} · {mood?.label}
+                </Badge>
+              </div>
+              {log.note && (
+                <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                  {log.note}
+                </p>
+              )}
+            </div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/* ── Main Page ────────────────────────────────────────────── */
+
+export default function MoodHistoryClient() {
+  const { data: logs = [], isLoading } = useMoodLogs(365)
+  const createMut = useCreateMoodLog()
+  const updateMut = useUpdateMoodLog()
+
+  const now = new Date()
+  const [viewYear, setViewYear] = useState(now.getFullYear())
+  const [viewMonth, setViewMonth] = useState(now.getMonth())
+  const [selectedDay, setSelectedDay] = useState<string | null>(null)
+  const [showGate, setShowGate] = useState(false)
+
+  const isSaving = createMut.isPending || updateMut.isPending
+
+  /* Build a lookup map from all logs */
+  const logMap = useMemo(() => {
+    const m = new Map<string, MoodLog>()
+    for (const log of logs) m.set(log.logged_at, log)
+    return m
+  }, [logs])
+
+  /* Logs for the viewed month, sorted newest-first */
+  const monthLogs = useMemo(() => {
+    const prefix = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}`
+    return logs
+      .filter((l) => l.logged_at.startsWith(prefix))
+      .sort((a, b) => b.logged_at.localeCompare(a.logged_at))
+  }, [logs, viewYear, viewMonth])
+
+  /* Month stats */
+  const monthAvg = useMemo(() => {
+    if (monthLogs.length === 0) return null
+    const sum = monthLogs.reduce((s, l) => s + Number(l.mood_score), 0)
+    return Number((sum / monthLogs.length).toFixed(1))
+  }, [monthLogs])
+
+  /* Navigation */
+  function prevMonth() {
+    if (viewMonth === 0) {
+      setViewMonth(11)
+      setViewYear((y) => y - 1)
+    } else {
+      setViewMonth((m) => m - 1)
+    }
+    setSelectedDay(null)
+  }
+
+  function nextMonth() {
+    const isCurrentMonth =
+      viewYear === now.getFullYear() && viewMonth === now.getMonth()
+    if (isCurrentMonth) return
+    if (viewMonth === 11) {
+      setViewMonth(0)
+      setViewYear((y) => y + 1)
+    } else {
+      setViewMonth((m) => m + 1)
+    }
+    setSelectedDay(null)
+  }
+
+  const isCurrentMonth =
+    viewYear === now.getFullYear() && viewMonth === now.getMonth()
+
+  /* Day click → open detail panel */
+  function handleDayClick(dateKey: string) {
+    setSelectedDay((prev) => (prev === dateKey ? null : dateKey))
+  }
+
+  /* Save / update from detail panel */
+  async function handleDaySave(score: number, note: string) {
+    if (!selectedDay) return
+    const existing = logMap.get(selectedDay)
+
+    try {
+      if (existing) {
+        await updateMut.mutateAsync({
+          id: existing.id,
+          input: { mood_score: score, note },
+        })
+        toast.success("Mood updated")
+      } else {
+        const gate = await canCreateMoodLog(selectedDay)
+        if (!gate.allowed) {
+          setShowGate(true)
+          return
+        }
+        await createMut.mutateAsync({
+          mood_score: score,
+          note,
+          logged_at: selectedDay,
+        })
+        toast.success("Mood logged")
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "Failed to save"
+      if (msg.includes("Upgrade to Premium")) {
+        setShowGate(true)
+      } else {
+        toast.error(msg)
+      }
+    }
+  }
+
+  const selectedLog = selectedDay ? logMap.get(selectedDay) ?? null : null
+
+  return (
+    <>
+      <SiteHeader />
+
+      <main className="flex flex-1 flex-col items-center px-4 pb-16 md:px-8">
+        <div className="w-full max-w-2xl py-8 md:py-14">
+          {/* ── Header ──────────────────────────────────── */}
+          <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between md:mb-12">
+            <div className="space-y-2">
+              <Badge
+                variant="outline"
+                className="gap-1.5 rounded-full px-3.5 py-1"
+              >
+                <HeartPulse className="h-3.5 w-3.5" />
+                History
+              </Badge>
+              <h1 className="text-2xl font-primary tracking-tight md:text-3xl">
+                Mood History
+              </h1>
+              <p className="max-w-md text-sm text-muted-foreground">
+                Look back at how you&apos;ve been feeling over time.
+              </p>
+            </div>
+
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/dashboard/mood">Log today&apos;s mood</Link>
+            </Button>
+          </div>
+
+          {/* ── Month navigation ─────────────────────────── */}
+          <div className="mb-6 flex items-center justify-between">
+            <Button variant="ghost" size="icon" onClick={prevMonth} className="h-8 w-8">
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+
+            <div className="text-center">
+              <p className="text-sm font-semibold">
+                {formatMonthYear(viewYear, viewMonth)}
+              </p>
+              {monthAvg !== null && (
+                <p className="text-xs text-muted-foreground">
+                  {monthLogs.length} {monthLogs.length === 1 ? "entry" : "entries"} · avg {formatMoodScore(monthAvg)}
+                </p>
+              )}
+            </div>
+
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={nextMonth}
+              disabled={isCurrentMonth}
+              className="h-8 w-8"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+
+          {/* ── Calendar heatmap ─────────────────────────── */}
+          {isLoading ? (
+            <div className="grid grid-cols-7 gap-1">
+              {Array.from({ length: 35 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="aspect-square animate-pulse rounded-lg bg-muted/30"
+                />
+              ))}
+            </div>
+          ) : (
+            <CalendarHeatmap
+              year={viewYear}
+              month={viewMonth}
+              logMap={logMap}
+              onDayClick={handleDayClick}
+              selectedDay={selectedDay}
+            />
+          )}
+
+          {/* ── Day detail panel ─────────────────────────── */}
+          <AnimatePresence mode="wait">
+            {selectedDay && (
+              <div className="mt-6" key={selectedDay}>
+                <DayDetail
+                  dateKey={selectedDay}
+                  log={selectedLog}
+                  onClose={() => setSelectedDay(null)}
+                  onSave={handleDaySave}
+                  isSaving={isSaving}
+                />
+              </div>
+            )}
+          </AnimatePresence>
+
+          {/* ── Divider ──────────────────────────────────── */}
+          <div className="my-10 border-t border-border/30" />
+
+          {/* ── Entry list ───────────────────────────────── */}
+          <div className="space-y-4">
+            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+              {formatMonthYear(viewYear, viewMonth)} Entries
+            </h2>
+
+            {isLoading ? (
+              <div className="space-y-2">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-16 animate-pulse rounded-xl bg-muted/30"
+                  />
+                ))}
+              </div>
+            ) : (
+              <EntryList logs={monthLogs} onEntryClick={handleDayClick} />
+            )}
+          </div>
+        </div>
+      </main>
+
+      <PremiumGateModal
+        open={showGate}
+        onOpenChange={setShowGate}
+        reason="mood"
+      />
+    </>
+  )
+}

--- a/app/(dashboard)/dashboard/mood/history/page.tsx
+++ b/app/(dashboard)/dashboard/mood/history/page.tsx
@@ -1,0 +1,5 @@
+import MoodHistoryClient from "./mood-history-client"
+
+export default function MoodHistoryPage() {
+  return <MoodHistoryClient />
+}

--- a/app/(dashboard)/dashboard/mood/mood-page-client.tsx
+++ b/app/(dashboard)/dashboard/mood/mood-page-client.tsx
@@ -1,0 +1,318 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { motion, AnimatePresence } from "framer-motion"
+import { Check, HeartPulse, History } from "lucide-react"
+import { canCreateMoodLog } from "@/app/actions/usage-limits"
+import { PremiumGateModal } from "@/components/premium-gate-modal"
+import { SiteHeader } from "@/components/site-header"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  useMoodLogs,
+  useCreateMoodLog,
+  useUpdateMoodLog,
+} from "@/hooks/use-mood-logs"
+import { MOOD_SCALE, formatMoodScore } from "@/lib/mood"
+import { cn } from "@/lib/utils"
+import { toast } from "sonner"
+
+function getTodayDate() {
+  return new Date().toISOString().split("T")[0]
+}
+
+function formatTimeLabel(ts: string | null) {
+  if (!ts) return null
+  return new Date(ts).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+/* ────────────────────────── Page ────────────────────────── */
+
+export default function MoodPageClient() {
+  const { data: logs = [], isLoading } = useMoodLogs()
+  const createMut = useCreateMoodLog()
+  const updateMut = useUpdateMoodLog()
+
+  const today = getTodayDate()
+  const todayLog = logs.find((l) => l.logged_at === today) ?? null
+
+  const [selectedScore, setSelectedScore] = useState<number | null>(null)
+  const [note, setNote] = useState("")
+  const [noteDirty, setNoteDirty] = useState(false)
+  const [showGate, setShowGate] = useState(false)
+  const [justSaved, setJustSaved] = useState(false)
+
+  /* Sync UI from today's log whenever it changes */
+  useEffect(() => {
+    if (todayLog) {
+      setSelectedScore(Number(todayLog.mood_score))
+      setNote(todayLog.note ?? "")
+      setNoteDirty(false)
+    }
+    // Only reset when no log AND we haven't interacted yet
+    if (!todayLog && !createMut.isPending) {
+      setSelectedScore(null)
+      setNote("")
+      setNoteDirty(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [todayLog?.id])
+
+  const isSaving = createMut.isPending || updateMut.isPending
+
+  /* ── One-tap mood save ────────────────────────────────── */
+  async function handleMoodTap(score: number) {
+    if (isSaving) return
+    const prev = selectedScore
+    setSelectedScore(score)
+
+    try {
+      if (todayLog) {
+        await updateMut.mutateAsync({
+          id: todayLog.id,
+          input: { mood_score: score },
+        })
+      } else {
+        const gate = await canCreateMoodLog(today)
+        if (!gate.allowed) {
+          setSelectedScore(prev)
+          setShowGate(true)
+          return
+        }
+        await createMut.mutateAsync({
+          mood_score: score,
+          logged_at: today,
+        })
+      }
+      setJustSaved(true)
+      setTimeout(() => setJustSaved(false), 2200)
+      toast.success(todayLog ? "Mood updated" : "Mood logged", {
+        duration: 2000,
+      })
+    } catch (error) {
+      setSelectedScore(prev)
+      const msg =
+        error instanceof Error ? error.message : "Failed to save mood"
+      if (msg.includes("Upgrade to Premium")) {
+        setShowGate(true)
+      } else {
+        toast.error(msg)
+      }
+    }
+  }
+
+  /* ── Save note ────────────────────────────────────────── */
+  async function handleNoteSave() {
+    if (!todayLog || !noteDirty) return
+    try {
+      await updateMut.mutateAsync({
+        id: todayLog.id,
+        input: { note },
+      })
+      setNoteDirty(false)
+      toast.success("Note saved", { duration: 1500 })
+    } catch {
+      toast.error("Could not save note")
+    }
+  }
+
+  /* ── Derived state ────────────────────────────────────── */
+  const selected = MOOD_SCALE.find((o) => o.value === selectedScore) ?? null
+  const loggedTime = formatTimeLabel(todayLog?.created_at ?? null)
+
+  return (
+    <>
+      <SiteHeader />
+
+      <main className="flex flex-1 flex-col items-center px-4 pb-16 md:px-8">
+        <div className="w-full max-w-2xl py-8 md:py-14">
+          {/* ── Header ───────────────────────────────────── */}
+          <div className="mb-10 space-y-3 text-center md:mb-14">
+            <Badge
+              variant="outline"
+              className="mx-auto gap-1.5 rounded-full px-3.5 py-1"
+            >
+              <HeartPulse className="h-3.5 w-3.5" />
+              Mood
+            </Badge>
+
+            <h1 className="text-2xl font-primary tracking-tight md:text-3xl">
+              Today&apos;s Mood
+            </h1>
+            <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground md:text-base">
+              How are you feeling right now?
+            </p>
+            <Button variant="ghost" size="sm" className="mx-auto mt-1 gap-1.5 text-muted-foreground" asChild>
+              <Link href="/dashboard/mood/history">
+                <History className="h-3.5 w-3.5" />
+                View history
+              </Link>
+            </Button>
+          </div>
+
+          {/* ── Mood selector grid ───────────────────────── */}
+          <div className="grid grid-cols-3 gap-2.5 sm:grid-cols-5 lg:grid-cols-9 lg:gap-3">
+            {MOOD_SCALE.map((option) => {
+              const isActive = selectedScore === option.value
+              return (
+                <motion.button
+                  key={option.value}
+                  type="button"
+                  onClick={() => handleMoodTap(option.value)}
+                  whileTap={{ scale: 0.93 }}
+                  disabled={isSaving}
+                  className={cn(
+                    "relative flex flex-col items-center justify-center rounded-2xl border-2 p-3 transition-all duration-200",
+                    "min-h-[96px] select-none",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2",
+                    isActive
+                      ? `${option.softAccent} ${option.border} shadow-md`
+                      : "border-border/40 bg-background hover:border-border hover:bg-muted/15",
+                    isSaving && "pointer-events-none opacity-60"
+                  )}
+                >
+                  {/* Emoji */}
+                  <span
+                    className={cn(
+                      "text-2xl leading-none transition-transform duration-200",
+                      isActive && "scale-110"
+                    )}
+                  >
+                    {option.emoji}
+                  </span>
+
+                  {/* Score */}
+                  <span
+                    className={cn(
+                      "mt-1.5 text-sm font-semibold tabular-nums leading-none",
+                      isActive ? option.text : "text-foreground/80"
+                    )}
+                  >
+                    {formatMoodScore(option.value)}
+                  </span>
+
+                  {/* Label */}
+                  <span
+                    className={cn(
+                      "mt-1 text-[10px] font-medium leading-tight",
+                      isActive ? option.text : "text-muted-foreground"
+                    )}
+                  >
+                    {option.label}
+                  </span>
+
+                  {/* Saved check */}
+                  <AnimatePresence>
+                    {isActive && justSaved && (
+                      <motion.span
+                        initial={{ scale: 0, opacity: 0 }}
+                        animate={{ scale: 1, opacity: 1 }}
+                        exit={{ scale: 0, opacity: 0 }}
+                        className={cn(
+                          "absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full text-white shadow-sm",
+                          option.accent
+                        )}
+                      >
+                        <Check className="h-3 w-3" strokeWidth={3} />
+                      </motion.span>
+                    )}
+                  </AnimatePresence>
+                </motion.button>
+              )
+            })}
+          </div>
+
+          {/* ── Loading skeleton ──────────────────────────── */}
+          {isLoading && (
+            <div className="mt-6 flex justify-center">
+              <div className="h-4 w-32 animate-pulse rounded-full bg-muted/40" />
+            </div>
+          )}
+
+          {/* ── Selected mood detail ─────────────────────── */}
+          <AnimatePresence mode="wait">
+            {selected && !isLoading && (
+              <motion.div
+                key={selected.value}
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -4 }}
+                transition={{ duration: 0.2 }}
+                className="mx-auto mt-8 max-w-md text-center"
+              >
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  {selected.description}
+                </p>
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* ── Note section (visible once logged) ────────── */}
+          <AnimatePresence>
+            {todayLog && (
+              <motion.div
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.25 }}
+                className="mx-auto mt-10 w-full max-w-md space-y-3 overflow-hidden"
+              >
+                <label className="block text-xs font-medium text-muted-foreground">
+                  Note&ensp;
+                  <span className="font-normal">(optional)</span>
+                </label>
+                <Textarea
+                  placeholder="Anything you want to remember about today..."
+                  value={note}
+                  onChange={(e) => {
+                    setNote(e.target.value)
+                    setNoteDirty(true)
+                  }}
+                  rows={3}
+                  className="resize-none bg-muted/10"
+                />
+                <AnimatePresence>
+                  {noteDirty && (
+                    <motion.div
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      className="flex justify-end"
+                    >
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleNoteSave}
+                        disabled={updateMut.isPending}
+                      >
+                        Save note
+                      </Button>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* ── Status line ──────────────────────────────── */}
+          {todayLog && loggedTime && (
+            <p className="mt-6 text-center text-xs text-muted-foreground/70">
+              Logged at {loggedTime}
+            </p>
+          )}
+        </div>
+      </main>
+
+      <PremiumGateModal
+        open={showGate}
+        onOpenChange={setShowGate}
+        reason="mood"
+      />
+    </>
+  )
+}

--- a/app/(dashboard)/dashboard/mood/page.tsx
+++ b/app/(dashboard)/dashboard/mood/page.tsx
@@ -1,0 +1,5 @@
+import MoodPageClient from './mood-page-client'
+
+export default function MoodPage() {
+  return <MoodPageClient />
+}

--- a/app/actions/moodLogs.ts
+++ b/app/actions/moodLogs.ts
@@ -1,0 +1,172 @@
+'use server'
+
+import { canCreateMoodLog } from '@/app/actions/usage-limits'
+import { createClient } from '@/lib/supabase/server'
+import type {
+  ActionResponse,
+  CreateMoodLogInput,
+  MoodLog,
+  UpdateMoodLogInput,
+} from '@/types/database'
+
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) return error.message
+  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+    return error.message
+  }
+  return fallback
+}
+
+
+async function getAuthenticatedUser() {
+  const supabase = await createClient()
+  const { data: { user }, error } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    throw new Error('Not authenticated')
+  }
+
+  return { user, supabase }
+}
+
+function normalizeMoodScore(value: number) {
+  const rounded = Math.round(value * 2) / 2
+
+  if (rounded < 1 || rounded > 5) {
+    throw new Error('Mood score must be between 1 and 5.')
+  }
+
+  return rounded
+}
+
+function normalizeLoggedAt(value?: string) {
+  return value ?? new Date().toISOString().split('T')[0]
+}
+
+export async function getMoodLogs(limit = 90): Promise<ActionResponse<MoodLog[]>> {
+  try {
+    const { user, supabase } = await getAuthenticatedUser()
+
+    const { data, error } = await supabase
+      .from('mood_logs')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('logged_at', { ascending: false })
+      .order('created_at', { ascending: false })
+      .limit(limit)
+
+    if (error) throw error
+
+    return { data: (data ?? []) as MoodLog[] }
+  } catch (error) {
+    console.error('getMoodLogs error:', error)
+    return { error: error instanceof Error ? error.message : 'Failed to fetch mood logs' }
+  }
+}
+
+export async function createMoodLog(input: CreateMoodLogInput): Promise<ActionResponse<MoodLog>> {
+  try {
+    const { user, supabase } = await getAuthenticatedUser()
+    const loggedAt = normalizeLoggedAt(input.logged_at)
+    const moodScore = normalizeMoodScore(input.mood_score)
+
+    const limit = await canCreateMoodLog(loggedAt)
+    if (!limit.allowed) {
+      throw new Error('Free users can save 1 mood log per day. Upgrade to Premium for more.')
+    }
+
+    const { data, error } = await supabase
+      .from('mood_logs')
+      .insert({
+        user_id: user.id,
+        mood_score: moodScore,
+        note: input.note?.trim() || null,
+        logged_at: loggedAt,
+      })
+      .select()
+      .single()
+
+    if (error) throw error
+
+    return { data: data as MoodLog }
+  } catch (error) {
+    console.error('createMoodLog error:', error)
+    return { error: extractErrorMessage(error, 'Failed to create mood log') }
+  }
+}
+
+export async function updateMoodLog(
+  id: number,
+  input: UpdateMoodLogInput
+): Promise<ActionResponse<MoodLog>> {
+  try {
+    const { user, supabase } = await getAuthenticatedUser()
+
+    const { data: existing, error: existingError } = await supabase
+      .from('mood_logs')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .single()
+
+    if (existingError || !existing) {
+      throw new Error('Mood log not found.')
+    }
+
+    const loggedAt = normalizeLoggedAt(input.logged_at ?? existing.logged_at)
+    if (loggedAt !== existing.logged_at) {
+      const limit = await canCreateMoodLog(loggedAt)
+      if (!limit.allowed) {
+        throw new Error('Free users can save 1 mood log per day. Upgrade to Premium for more.')
+      }
+    }
+
+    const updates: Record<string, unknown> = {}
+
+    if (input.mood_score !== undefined) {
+      updates.mood_score = normalizeMoodScore(input.mood_score)
+    }
+
+    if (input.note !== undefined) {
+      updates.note = input.note?.trim() || null
+    }
+
+    if (input.logged_at !== undefined) {
+      updates.logged_at = loggedAt
+    }
+
+    const { data, error } = await supabase
+      .from('mood_logs')
+      .update(updates)
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .select()
+      .single()
+
+    if (error) throw error
+
+    return { data: data as MoodLog }
+  } catch (error) {
+    console.error('updateMoodLog error:', error)
+    return { error: extractErrorMessage(error, 'Failed to update mood log') }
+  }
+}
+
+export async function deleteMoodLog(id: number): Promise<ActionResponse<{ success: boolean }>> {
+  try {
+    const { user, supabase } = await getAuthenticatedUser()
+
+    const { error } = await supabase
+      .from('mood_logs')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id)
+
+    if (error) throw error
+
+    return { data: { success: true } }
+  } catch (error) {
+    console.error('deleteMoodLog error:', error)
+    return { error: extractErrorMessage(error, 'Failed to delete mood log') }
+  }
+}

--- a/app/actions/usage-limits.ts
+++ b/app/actions/usage-limits.ts
@@ -84,3 +84,29 @@ export async function canCreateHabit(): Promise<{ allowed: boolean; count: numbe
   const currentCount = count ?? 0
   return { allowed: currentCount < 3, count: currentCount, limit: 3 }
 }
+
+/**
+ * Check if the user can create a mood log on a given day.
+ * Free users: 1 mood log/day. Premium users: unlimited.
+ */
+export async function canCreateMoodLog(
+  loggedAt?: string
+): Promise<{ allowed: boolean; count: number; limit: number }> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) return { allowed: false, count: 0, limit: 1 }
+
+  if (await isCurrentUserPremium()) return { allowed: true, count: 0, limit: Infinity }
+
+  const targetDate = loggedAt ?? new Date().toISOString().split('T')[0]
+
+  const { count } = await supabase
+    .from('mood_logs')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', user.id)
+    .eq('logged_at', targetDate)
+
+  const currentCount = count ?? 0
+  return { allowed: currentCount < 1, count: currentCount, limit: 1 }
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   CalendarSync,
   CalendarDays,
   ClockArrowUp,
+  HeartPulse,
   Home,
   ListCheck,
   NotebookPen,
@@ -57,6 +58,24 @@ const navigationItems = [
     url: "/dashboard/focus",
     icon: ClockArrowUp,
     section: "focus",
+  },
+  {
+    title: "Mood",
+    url: "/dashboard/mood",
+    icon: HeartPulse,
+    section: "mood",
+    items: [
+      {
+        title: "Log",
+        url: "/dashboard/mood",
+        icon: HeartPulse,
+      },
+      {
+        title: "History",
+        url: "/dashboard/mood/history",
+        icon: CalendarDays,
+      },
+    ],
   },
   {
     title: "Journal",

--- a/components/premium-gate-modal.tsx
+++ b/components/premium-gate-modal.tsx
@@ -13,7 +13,7 @@ import { Crown, Sparkles, Lock, Zap } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { motion } from "framer-motion"
 
-export type PremiumGateReason = "journal" | "task" | "habit"
+export type PremiumGateReason = "journal" | "task" | "habit" | "mood"
 
 const GATE_CONFIG: Record<PremiumGateReason, {
   title: string
@@ -35,9 +35,15 @@ const GATE_CONFIG: Record<PremiumGateReason, {
   },
   habit: {
     title: "Habit Limit Reached",
-    description: "Free users can track up to 5 habits.",
-    limit: "5 habits total",
+    description: "Free users can track up to 3 habits.",
+    limit: "3 habits total",
     icon: Sparkles,
+  },
+  mood: {
+    title: "Mood Log Limit Reached",
+    description: "Free users can save 1 mood log per day.",
+    limit: "1 mood log/day",
+    icon: Lock,
   },
 }
 
@@ -99,7 +105,7 @@ export function PremiumGateModal({ open, onOpenChange, reason }: PremiumGateModa
             With Premium you get
           </p>
           <div className="grid gap-1.5">
-            {["Unlimited journals every day", "Unlimited tasks", "Unlimited habits", "Custom themes & more"].map((perk) => (
+            {["Unlimited journals every day", "Unlimited tasks", "Unlimited mood logs", "Custom themes & more"].map((perk) => (
               <div key={perk} className="flex items-center gap-2 text-sm">
                 <Crown className="h-3.5 w-3.5 text-amber-500 shrink-0" />
                 <span className="text-muted-foreground">{perk}</span>

--- a/components/sidebar-right-wrapper.tsx
+++ b/components/sidebar-right-wrapper.tsx
@@ -10,7 +10,7 @@ export function SidebarRightWrapper() {
   const pathname = usePathname()
   
   // Hide sidebar on settings and weekly pages
-  if (pathname?.startsWith('/settings') || pathname?.startsWith('/dashboard/week') || pathname?.startsWith('/dashboard/tasks')) {
+  if (pathname?.startsWith('/settings') || pathname?.startsWith('/dashboard/week') || pathname?.startsWith('/dashboard/tasks') || pathname?.startsWith('/dashboard/mood') || pathname?.startsWith('/dashboard/mood')) {
     return null
   }
   

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -21,6 +21,7 @@ const sectionTitles: Record<string, string> = {
   goals: "Goals",
   habits: "Habits",
   focus: "Focus",
+  mood: "Mood",
   ai: "Rhythmé AI",
   account: "Account",
   notifications: "Notifications",

--- a/hooks/use-mood-logs.ts
+++ b/hooks/use-mood-logs.ts
@@ -1,0 +1,77 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  createMoodLog,
+  deleteMoodLog,
+  getMoodLogs,
+  updateMoodLog,
+} from "@/app/actions/moodLogs"
+import type { CreateMoodLogInput, UpdateMoodLogInput } from "@/types/database"
+
+export const moodKeys = {
+  all: ["mood-logs"] as const,
+}
+
+export function useMoodLogs(limit = 90) {
+  return useQuery({
+    queryKey: [...moodKeys.all, limit],
+    queryFn: async () => {
+      const result = await getMoodLogs(limit)
+      if (result.error) throw new Error(result.error)
+      return result.data || []
+    },
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useCreateMoodLog() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: CreateMoodLogInput) => {
+      const result = await createMoodLog(input)
+      if (result.error) throw new Error(result.error)
+      return result.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: moodKeys.all })
+    },
+  })
+}
+
+export function useUpdateMoodLog() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      input,
+    }: {
+      id: number
+      input: UpdateMoodLogInput
+    }) => {
+      const result = await updateMoodLog(id, input)
+      if (result.error) throw new Error(result.error)
+      return result.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: moodKeys.all })
+    },
+  })
+}
+
+export function useDeleteMoodLog() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const result = await deleteMoodLog(id)
+      if (result.error) throw new Error(result.error)
+      return result.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: moodKeys.all })
+    },
+  })
+}

--- a/hooks/use-warm-services.ts
+++ b/hooks/use-warm-services.ts
@@ -55,10 +55,10 @@ export function useWarmServices(): UseWarmServicesResult {
       };
     }
 
-    const timeoutId = window.setTimeout(runWarmUp, 1200);
+    const timeoutId = globalThis.setTimeout(runWarmUp, 1200);
     return () => {
       cancelled = true;
-      window.clearTimeout(timeoutId);
+      globalThis.clearTimeout(timeoutId);
     };
   }, [warmUp]);
 

--- a/lib/mood.ts
+++ b/lib/mood.ts
@@ -1,0 +1,105 @@
+export const MOOD_SCALE = [
+  {
+    value: 1,
+    emoji: '😢',
+    label: 'Drained',
+    description: 'Everything feels heavier than usual.',
+    accent: 'bg-rose-500',
+    softAccent: 'bg-rose-500/10',
+    text: 'text-rose-600',
+    border: 'border-rose-500/30',
+  },
+  {
+    value: 1.5,
+    emoji: '😞',
+    label: 'Low',
+    description: 'You are getting through the day with limited bandwidth.',
+    accent: 'bg-orange-500',
+    softAccent: 'bg-orange-500/10',
+    text: 'text-orange-600',
+    border: 'border-orange-500/30',
+  },
+  {
+    value: 2,
+    emoji: '🙁',
+    label: 'Heavy',
+    description: 'A bit weighed down, tense, or mentally cluttered.',
+    accent: 'bg-amber-500',
+    softAccent: 'bg-amber-500/10',
+    text: 'text-amber-600',
+    border: 'border-amber-500/30',
+  },
+  {
+    value: 2.5,
+    emoji: '😐',
+    label: 'Uneasy',
+    description: 'Not at your best, but there is still some footing.',
+    accent: 'bg-yellow-500',
+    softAccent: 'bg-yellow-500/10',
+    text: 'text-yellow-600',
+    border: 'border-yellow-500/30',
+  },
+  {
+    value: 3,
+    emoji: '🙂',
+    label: 'Steady',
+    description: 'A balanced middle ground.',
+    accent: 'bg-lime-500',
+    softAccent: 'bg-lime-500/10',
+    text: 'text-lime-600',
+    border: 'border-lime-500/30',
+  },
+  {
+    value: 3.5,
+    emoji: '😌',
+    label: 'Grounded',
+    description: 'Centered, calm, and reasonably present.',
+    accent: 'bg-emerald-500',
+    softAccent: 'bg-emerald-500/10',
+    text: 'text-emerald-600',
+    border: 'border-emerald-500/30',
+  },
+  {
+    value: 4,
+    emoji: '😊',
+    label: 'Bright',
+    description: 'You have energy and emotional room to move.',
+    accent: 'bg-sky-500',
+    softAccent: 'bg-sky-500/10',
+    text: 'text-sky-600',
+    border: 'border-sky-500/30',
+  },
+  {
+    value: 4.5,
+    emoji: '😄',
+    label: 'Lifted',
+    description: 'Things feel light, capable, and encouraging.',
+    accent: 'bg-blue-500',
+    softAccent: 'bg-blue-500/10',
+    text: 'text-blue-600',
+    border: 'border-blue-500/30',
+  },
+  {
+    value: 5,
+    emoji: '🌟',
+    label: 'Excellent',
+    description: 'You feel strong, clear, and fully switched on.',
+    accent: 'bg-violet-500',
+    softAccent: 'bg-violet-500/10',
+    text: 'text-violet-600',
+    border: 'border-violet-500/30',
+  },
+] as const
+
+export function formatMoodScore(score: number) {
+  return Number.isInteger(score) ? String(score) : score.toFixed(1)
+}
+
+export function getMoodOption(score: number | null | undefined) {
+  if (score === null || score === undefined) return null
+  return MOOD_SCALE.find((option) => option.value === score) ?? null
+}
+
+export function getMoodSummaryLabel(score: number | null | undefined) {
+  return getMoodOption(score)?.label ?? 'No mood logged'
+}

--- a/store/nav-store.ts
+++ b/store/nav-store.ts
@@ -1,7 +1,7 @@
 // store/navigation-store.ts
 import { create } from 'zustand'
 
-type Section = 'overview' | 'analytics' | 'data-table' | 'settings' | 'tasks' | 'goals' | 'habits' | 'focus'
+type Section = 'overview' | 'analytics' | 'data-table' | 'settings' | 'tasks' | 'goals' | 'habits' | 'focus' | 'mood'
 
 interface NavigationState {
   activeSection: Section

--- a/supabase/migrations/20260506_mood_logs_and_focus_updates.sql
+++ b/supabase/migrations/20260506_mood_logs_and_focus_updates.sql
@@ -1,0 +1,20 @@
+alter table if exists public.mood_logs
+  drop constraint if exists mood_logs_user_date_unique;
+
+alter table if exists public.mood_logs
+  alter column mood_score type numeric(2,1)
+  using mood_score::numeric(2,1);
+
+alter table if exists public.mood_logs
+  drop constraint if exists mood_logs_mood_score_check;
+
+alter table if exists public.mood_logs
+  add constraint mood_logs_mood_score_check
+  check (
+    mood_score >= 1
+    and mood_score <= 5
+    and mod((mood_score * 10)::integer, 5) = 0
+  );
+
+alter table if exists public.focus_sessions
+  alter column task_id drop not null;

--- a/types/database.ts
+++ b/types/database.ts
@@ -115,6 +115,29 @@ export interface HabitWithStats extends Habit {
   daysUntilPrediction?: number  // Days remaining until AI predictions are available
 }
 
+// Mood logs
+export interface MoodLog {
+  id: number
+  user_id: string
+  mood_score: number
+  note: string | null
+  logged_at: string
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateMoodLogInput {
+  mood_score: number
+  note?: string
+  logged_at?: string
+}
+
+export interface UpdateMoodLogInput {
+  mood_score?: number
+  note?: string | null
+  logged_at?: string
+}
+
 // Journals 
 
 export interface JournalMoodTags {


### PR DESCRIPTION
Implements a new mood tracking feature across the app. Adds client pages and UI (today's mood and history heatmap), a mood lib (MOOD_SCALE, helpers), React Query hooks (use-mood-logs), and server actions for CRUD (app/actions/moodLogs). Enforces free-user limits via canCreateMoodLog in usage-limits and updates the PremiumGateModal and sidebar/navigation to expose Mood. Includes a DB migration to relax/normalize mood_score (numeric(2,1)), add a check constraint for half-step values, and remove a unique constraint; also drops not-null on focus_sessions.task_id. Misc: small fixes to warm-up hook (use globalThis) and nav store typing.