### PR TITLE
Add Focus hub UI, session CRUD & history

### DIFF
--- a/app/(dashboard)/dashboard/focus/[session_id]/loading.tsx
+++ b/app/(dashboard)/dashboard/focus/[session_id]/loading.tsx
@@ -1,0 +1,20 @@
+import { SiteHeader } from "@/components/site-header";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SessionDetailLoading() {
+  return (
+    <>
+      <SiteHeader />
+      <div className="flex flex-1 flex-col px-4 md:px-10">
+        <div className="@container/main flex flex-1 flex-col gap-2">
+          <div className="flex flex-col gap-6 py-4 md:py-6 max-w-2xl mx-auto w-full">
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-32 rounded-2xl" />
+            <Skeleton className="h-48 rounded-2xl" />
+            <Skeleton className="h-24 rounded-2xl" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(dashboard)/dashboard/focus/[session_id]/page.tsx
+++ b/app/(dashboard)/dashboard/focus/[session_id]/page.tsx
@@ -1,0 +1,41 @@
+import { SiteHeader } from "@/components/site-header";
+import { SessionDetailClient } from "@/components/focus/session-detail-client";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Session Detail – Rhythmé",
+  description: "View details of a focus session",
+};
+
+export default async function SessionDetailPage({
+  params,
+}: {
+  params: Promise<{ session_id: string }>;
+}) {
+  const { session_id } = await params;
+  const sessionId = Number(session_id);
+
+  if (!Number.isFinite(sessionId)) {
+    return (
+      <>
+        <SiteHeader />
+        <div className="flex flex-1 flex-col items-center justify-center py-16">
+          <p className="text-destructive text-sm">Invalid session ID.</p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SiteHeader />
+      <div className="flex flex-1 flex-col px-4 md:px-10">
+        <div className="@container/main flex flex-1 flex-col gap-2">
+          <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+            <SessionDetailClient sessionId={sessionId} />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(dashboard)/dashboard/focus/history/loading.tsx
+++ b/app/(dashboard)/dashboard/focus/history/loading.tsx
@@ -1,0 +1,23 @@
+import { SiteHeader } from "@/components/site-header";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function FocusHistoryLoading() {
+  return (
+    <>
+      <SiteHeader />
+      <div className="flex flex-1 flex-col px-4 md:px-10">
+        <div className="@container/main flex flex-1 flex-col gap-2">
+          <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6 max-w-3xl mx-auto w-full">
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-64 rounded-2xl" />
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-20 rounded-xl" />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(dashboard)/dashboard/focus/history/page.tsx
+++ b/app/(dashboard)/dashboard/focus/history/page.tsx
@@ -1,20 +1,20 @@
 import { SiteHeader } from "@/components/site-header";
-import { FocusHubClient } from "@/components/focus/focus-hub-client";
+import { FocusHistoryClient } from "@/components/focus/focus-history-client";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Focus – Rhythmé",
-  description: "Start a calm, intentional focus session",
+  title: "Focus History – Rhythmé",
+  description: "Review your past focus sessions and patterns",
 };
 
-export default function FocusPage() {
+export default function FocusHistoryPage() {
   return (
     <>
       <SiteHeader />
       <div className="flex flex-1 flex-col px-4 md:px-10">
         <div className="@container/main flex flex-1 flex-col gap-2">
           <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-            <FocusHubClient />
+            <FocusHistoryClient />
           </div>
         </div>
       </div>

--- a/app/actions/focusSessions.ts
+++ b/app/actions/focusSessions.ts
@@ -1,7 +1,12 @@
 'use server'
 
 import { createClient } from "@/lib/supabase/server"
-import type { ActionResponse, FocusSession } from "@/types/database"
+import type {
+  ActionResponse,
+  FocusSession,
+  StartFocusSessionInput,
+  EndFocusSessionInput,
+} from "@/types/database"
 
 async function getAuthenticatedUser() {
   const supabase = await createClient()
@@ -14,21 +19,23 @@ async function getAuthenticatedUser() {
   return { user, supabase }
 }
 
+const FOCUS_SESSION_SELECT = `
+  *,
+  tasks:task_id (
+    task_id,
+    title,
+    status,
+    priority
+  )
+`
+
 export async function getFocusSessions(limit = 50): Promise<ActionResponse<FocusSession[]>> {
   try {
     const { user, supabase } = await getAuthenticatedUser()
 
     const { data, error } = await supabase
       .from('focus_sessions')
-      .select(`
-        *,
-        tasks:task_id (
-          task_id,
-          title,
-          status,
-          priority
-        )
-      `)
+      .select(FOCUS_SESSION_SELECT)
       .eq('user_id', user.id)
       .order('started_at', { ascending: false })
       .limit(limit)
@@ -42,6 +49,26 @@ export async function getFocusSessions(limit = 50): Promise<ActionResponse<Focus
   }
 }
 
+export async function getFocusSession(sessionId: number): Promise<ActionResponse<FocusSession>> {
+  try {
+    const { user, supabase } = await getAuthenticatedUser()
+
+    const { data, error } = await supabase
+      .from('focus_sessions')
+      .select(FOCUS_SESSION_SELECT)
+      .eq('session_id', sessionId)
+      .eq('user_id', user.id)
+      .single()
+
+    if (error) throw error
+
+    return { data: data as FocusSession }
+  } catch (error) {
+    console.error('getFocusSession error:', error)
+    return { error: error instanceof Error ? error.message : 'Failed to fetch focus session' }
+  }
+}
+
 export async function getFocusSessionsForMonth(year: number, month: number): Promise<ActionResponse<FocusSession[]>> {
   try {
     const { user, supabase } = await getAuthenticatedUser()
@@ -52,13 +79,7 @@ export async function getFocusSessionsForMonth(year: number, month: number): Pro
 
     const { data, error } = await supabase
       .from('focus_sessions')
-      .select(`
-        *,
-        tasks:task_id (
-          task_id,
-          title
-        )
-      `)
+      .select(FOCUS_SESSION_SELECT)
       .eq('user_id', user.id)
       .gte('started_at', startDate.toISOString())
       .lte('started_at', endDate.toISOString())
@@ -73,11 +94,34 @@ export async function getFocusSessionsForMonth(year: number, month: number): Pro
   }
 }
 
-export async function startFocusSession(input: {
-  taskId?: string | null
-  plannedDuration: number
-  metadata?: Record<string, unknown>
-}): Promise<ActionResponse<FocusSession>> {
+export async function getFocusSessionsPaginated(
+  page: number,
+  pageSize: number,
+  sortOrder: 'asc' | 'desc' = 'desc'
+): Promise<ActionResponse<{ sessions: FocusSession[]; total: number }>> {
+  try {
+    const { user, supabase } = await getAuthenticatedUser()
+
+    const from = page * pageSize
+    const to = from + pageSize - 1
+
+    const { data, error, count } = await supabase
+      .from('focus_sessions')
+      .select(FOCUS_SESSION_SELECT, { count: 'exact' })
+      .eq('user_id', user.id)
+      .order('started_at', { ascending: sortOrder === 'asc' })
+      .range(from, to)
+
+    if (error) throw error
+
+    return { data: { sessions: data as FocusSession[], total: count ?? 0 } }
+  } catch (error) {
+    console.error('getFocusSessionsPaginated error:', error)
+    return { error: error instanceof Error ? error.message : 'Failed to fetch focus sessions' }
+  }
+}
+
+export async function startFocusSession(input: StartFocusSessionInput): Promise<ActionResponse<FocusSession>> {
   try {
     const { user, supabase } = await getAuthenticatedUser()
     const taskIdStr = input.taskId !== null && input.taskId !== undefined ? String(input.taskId).trim() : ''
@@ -92,8 +136,13 @@ export async function startFocusSession(input: {
       .insert({
         user_id: user.id,
         task_id: taskId,
+        custom_task_text: input.customTaskText?.trim() || null,
         planned_duration: input.plannedDuration,
+        energy_start: input.energyStart ?? null,
+        mood_before: input.moodBefore ?? null,
+        tags: input.tags ?? null,
         interruptions: 0,
+        interruption_details: [],
         metadata: input.metadata ?? {},
       })
       .select()
@@ -112,18 +161,21 @@ export async function updateFocusSession(
   sessionId: number,
   updates: {
     interruptions?: number
+    interruptionDetails?: Array<{ type: string; label?: string; timestamp: string }>
     metadata?: Record<string, unknown>
   }
 ): Promise<ActionResponse<FocusSession>> {
   try {
     const { user, supabase } = await getAuthenticatedUser()
 
+    const updateObj: Record<string, unknown> = {}
+    if (updates.interruptions !== undefined) updateObj.interruptions = updates.interruptions
+    if (updates.interruptionDetails !== undefined) updateObj.interruption_details = updates.interruptionDetails
+    if (updates.metadata !== undefined) updateObj.metadata = updates.metadata
+
     const { data, error } = await supabase
       .from('focus_sessions')
-      .update({
-        ...(updates.interruptions !== undefined && { interruptions: updates.interruptions }),
-        ...(updates.metadata !== undefined && { metadata: updates.metadata }),
-      })
+      .update(updateObj)
       .eq('session_id', sessionId)
       .eq('user_id', user.id)
       .select()
@@ -138,12 +190,7 @@ export async function updateFocusSession(
   }
 }
 
-export async function endFocusSession(input: {
-  sessionId: number
-  actualDuration: number
-  interruptions?: number
-  metadata?: Record<string, unknown>
-}): Promise<ActionResponse<FocusSession>> {
+export async function endFocusSession(input: EndFocusSessionInput): Promise<ActionResponse<FocusSession>> {
   try {
     const { user, supabase } = await getAuthenticatedUser()
 
@@ -151,7 +198,10 @@ export async function endFocusSession(input: {
       .from('focus_sessions')
       .update({
         actual_duration: Math.max(0, Math.round(input.actualDuration)),
+        mood_after: input.moodAfter,
+        energy_end: input.energyEnd ?? null,
         interruptions: input.interruptions ?? 0,
+        interruption_details: input.interruptionDetails ?? [],
         ended_at: new Date().toISOString(),
         ...(input.metadata !== undefined && { metadata: input.metadata }),
       })
@@ -166,6 +216,30 @@ export async function endFocusSession(input: {
   } catch (error) {
     console.error('endFocusSession error:', error)
     return { error: error instanceof Error ? error.message : 'Failed to finish focus session' }
+  }
+}
+
+export async function updateFocusSessionNotes(
+  sessionId: number,
+  metadata: Record<string, unknown>
+): Promise<ActionResponse<FocusSession>> {
+  try {
+    const { user, supabase } = await getAuthenticatedUser()
+
+    const { data, error } = await supabase
+      .from('focus_sessions')
+      .update({ metadata })
+      .eq('session_id', sessionId)
+      .eq('user_id', user.id)
+      .select()
+      .single()
+
+    if (error) throw error
+
+    return { data: data as FocusSession }
+  } catch (error) {
+    console.error('updateFocusSessionNotes error:', error)
+    return { error: error instanceof Error ? error.message : 'Failed to update session notes' }
   }
 }
 

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -58,6 +58,18 @@ const navigationItems = [
     url: "/dashboard/focus",
     icon: ClockArrowUp,
     section: "focus",
+    items: [
+      {
+        title: "Session",
+        url: "/dashboard/focus",
+        icon: ClockArrowUp,
+      },
+      {
+        title: "History",
+        url: "/dashboard/focus/history",
+        icon: History,
+      },
+    ],
   },
   {
     title: "Mood",

--- a/components/focus-timer.tsx
+++ b/components/focus-timer.tsx
@@ -244,6 +244,7 @@ export default function FocusTimer() {
       const result = await endFocusSession({
         sessionId,
         actualDuration,
+        moodAfter: 3,
         metadata,
       })
 

--- a/components/focus/active-timer.tsx
+++ b/components/focus/active-timer.tsx
@@ -1,0 +1,354 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { EnergyBadge } from '@/components/focus/energy-selector'
+import { updateFocusSession } from '@/app/actions/focusSessions'
+import { formatTime } from '@/lib/focus-mode'
+import { cn } from '@/lib/utils'
+import {
+  Pause,
+  Play,
+  Plus,
+  Square,
+  AlertCircle,
+  Smartphone,
+  Brain,
+  Bell,
+  Users,
+  HelpCircle,
+} from 'lucide-react'
+import type { FocusSession, InterruptionDetail } from '@/types/database'
+
+const INTERRUPTION_TYPES = [
+  { type: 'notification' as const, label: 'Notification', icon: Bell },
+  { type: 'mind_wandering' as const, label: 'Mind Wandering', icon: Brain },
+  { type: 'phone' as const, label: 'Phone', icon: Smartphone },
+  { type: 'external' as const, label: 'External', icon: Users },
+  { type: 'other' as const, label: 'Other', icon: HelpCircle },
+]
+
+interface ActiveTimerProps {
+  session: FocusSession
+  onSessionEnd: (actualDuration: number, interruptions: InterruptionDetail[]) => void
+}
+
+export function ActiveTimer({ session, onSessionEnd }: ActiveTimerProps) {
+  const [isPaused, setIsPaused] = useState(false)
+  const [showInterruptionModal, setShowInterruptionModal] = useState(false)
+  const [customInterruptionText, setCustomInterruptionText] = useState('')
+  const [interruptions, setInterruptions] = useState<InterruptionDetail[]>(
+    (session.interruption_details as InterruptionDetail[]) ?? []
+  )
+  const [showEndConfirm, setShowEndConfirm] = useState(false)
+  const [displaySeconds, setDisplaySeconds] = useState(0)
+
+  const startedAtRef = useRef(new Date(session.started_at).getTime())
+  const pausedAtRef = useRef<number | null>(null)
+  const totalPausedRef = useRef(0)
+  const frameRef = useRef(0)
+
+  const plannedDuration = session.planned_duration
+  const taskLabel = session.custom_task_text || session.tasks?.title || 'Focus Session'
+
+  // Timer logic
+  const getElapsedSeconds = useCallback(() => {
+    const now = isPaused && pausedAtRef.current ? pausedAtRef.current : Date.now()
+    const elapsed = Math.floor((now - startedAtRef.current - totalPausedRef.current) / 1000)
+    return Math.max(0, elapsed)
+  }, [isPaused])
+
+  const getRemainingSeconds = useCallback(() => {
+    return Math.max(0, plannedDuration - getElapsedSeconds())
+  }, [plannedDuration, getElapsedSeconds])
+
+  // Animation frame loop for timer
+  useEffect(() => {
+    const tick = () => {
+      const remaining = getRemainingSeconds()
+      setDisplaySeconds(remaining)
+
+      if (remaining <= 0) {
+        // Timer completed naturally
+        onSessionEnd(plannedDuration, interruptions)
+        return
+      }
+
+      if (!isPaused) {
+        frameRef.current = requestAnimationFrame(tick)
+      }
+    }
+
+    if (!isPaused) {
+      frameRef.current = requestAnimationFrame(tick)
+    }
+
+    return () => {
+      if (frameRef.current) {
+        cancelAnimationFrame(frameRef.current)
+      }
+    }
+  }, [isPaused, getRemainingSeconds, plannedDuration, onSessionEnd, interruptions])
+
+  // Update display when paused
+  useEffect(() => {
+    if (isPaused) {
+      setDisplaySeconds(getRemainingSeconds())
+    }
+  }, [isPaused, getRemainingSeconds])
+
+  // Play completion sound when timer hits 0
+  useEffect(() => {
+    if (displaySeconds === 0) {
+      try {
+        const audio = new Audio('/sounds/bell.mp3')
+        audio.play().catch(() => {})
+      } catch {
+        // Ignore autoplay errors
+      }
+    }
+  }, [displaySeconds])
+
+  const handlePause = useCallback(() => {
+    pausedAtRef.current = Date.now()
+    setIsPaused(true)
+  }, [])
+
+  const handleResume = useCallback(() => {
+    if (pausedAtRef.current) {
+      totalPausedRef.current += Date.now() - pausedAtRef.current
+      pausedAtRef.current = null
+    }
+    setIsPaused(false)
+  }, [])
+
+  const handleAddInterruption = useCallback(
+    async (type: InterruptionDetail['type'], label?: string) => {
+      const detail: InterruptionDetail = {
+        type,
+        label: label?.trim() || undefined,
+        timestamp: new Date().toISOString(),
+      }
+
+      const updated = [...interruptions, detail]
+      setInterruptions(updated)
+      setShowInterruptionModal(false)
+      setCustomInterruptionText('')
+
+      // Persist to DB
+      try {
+        await updateFocusSession(session.session_id, {
+          interruptions: updated.length,
+          interruptionDetails: updated,
+        })
+      } catch {
+        // Non-critical, local state is source of truth during active session
+      }
+    },
+    [interruptions, session.session_id]
+  )
+
+  const handleEndEarly = useCallback(() => {
+    const actualDuration = getElapsedSeconds()
+    onSessionEnd(actualDuration, interruptions)
+  }, [getElapsedSeconds, interruptions, onSessionEnd])
+
+  // Timer progress
+  const progress = plannedDuration > 0 ? 1 - displaySeconds / plannedDuration : 1
+
+  // Calculate estimated end time
+  const estimatedEnd = new Date(
+    Date.now() + displaySeconds * 1000
+  ).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+
+  const size = 320
+  const strokeWidth = 6
+  const radius = (size - strokeWidth) / 2
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference * (1 - Math.min(Math.max(progress, 0), 1))
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 bg-background flex flex-col items-center justify-center px-6 animate-in fade-in-0 duration-300">
+        {/* Task Label */}
+        <div className="absolute top-8 left-0 right-0 text-center">
+          <p className="text-sm font-medium text-muted-foreground uppercase tracking-wider truncate px-8 max-w-lg mx-auto">
+            {taskLabel}
+          </p>
+          {session.energy_start && (
+            <div className="mt-2 flex justify-center">
+              <EnergyBadge value={session.energy_start} />
+            </div>
+          )}
+        </div>
+
+        {/* Timer Dial */}
+        <div className="relative flex items-center justify-center aspect-square w-[min(75vw,320px)] max-w-full">
+          <svg
+            className="-rotate-90 absolute inset-0 h-full w-full"
+            viewBox={`0 0 ${size} ${size}`}
+            aria-hidden="true"
+            preserveAspectRatio="xMidYMid meet"
+          >
+            <circle
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              className="text-muted/20"
+            />
+            <circle
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={offset}
+              className="text-primary transition-all duration-1000 ease-linear"
+            />
+          </svg>
+
+          <div className="flex flex-col items-center justify-center text-center">
+            <span className="text-6xl sm:text-7xl font-bold tracking-tight text-foreground tabular-nums">
+              {formatTime(displaySeconds)}
+            </span>
+            <span className="mt-2 text-xs text-muted-foreground">
+              {isPaused ? 'PAUSED' : `ends ~${estimatedEnd}`}
+            </span>
+          </div>
+        </div>
+
+        {/* Elapsed info */}
+        <div className="mt-6 flex items-center gap-4 text-xs text-muted-foreground">
+          <span>Elapsed: {formatTime(getElapsedSeconds())}</span>
+          {interruptions.length > 0 && (
+            <span className="flex items-center gap-1">
+              <AlertCircle className="h-3 w-3" />
+              {interruptions.length} interruption{interruptions.length !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+
+        {/* Controls */}
+        <div className="mt-8 flex items-center gap-3">
+          {/* Pause / Resume */}
+          <Button
+            size="lg"
+            className="h-14 min-w-36 rounded-full text-base font-semibold"
+            onClick={isPaused ? handleResume : handlePause}
+          >
+            {isPaused ? (
+              <>
+                <Play className="mr-2 h-5 w-5" />
+                Resume
+              </>
+            ) : (
+              <>
+                <Pause className="mr-2 h-5 w-5" />
+                Pause
+              </>
+            )}
+          </Button>
+
+          {/* Add Interruption */}
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-12 w-12 rounded-full"
+            onClick={() => setShowInterruptionModal(true)}
+            title="Log interruption"
+          >
+            <Plus className="h-5 w-5" />
+          </Button>
+
+          {/* End Session Early */}
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-12 w-12 rounded-full text-destructive hover:bg-destructive/10 border-destructive/30"
+            onClick={() => setShowEndConfirm(true)}
+            title="End session early"
+          >
+            <Square className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Interruption Modal */}
+      <Dialog open={showInterruptionModal} onOpenChange={setShowInterruptionModal}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="text-base">What interrupted you?</DialogTitle>
+          </DialogHeader>
+          <div className="grid grid-cols-2 gap-2 py-2">
+            {INTERRUPTION_TYPES.map((item) => {
+              const Icon = item.icon
+              return (
+                <button
+                  key={item.type}
+                  type="button"
+                  onClick={() => handleAddInterruption(item.type)}
+                  className="flex items-center gap-2 rounded-xl border border-border/60 bg-background px-3 py-3 text-sm font-medium hover:bg-muted/60 transition-colors"
+                >
+                  <Icon className="h-4 w-4 text-muted-foreground" />
+                  {item.label}
+                </button>
+              )
+            })}
+          </div>
+          <div className="flex gap-2">
+            <Input
+              value={customInterruptionText}
+              onChange={(e) => setCustomInterruptionText(e.target.value)}
+              placeholder="Custom reason…"
+              className="text-sm"
+              maxLength={80}
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={!customInterruptionText.trim()}
+              onClick={() => handleAddInterruption('other', customInterruptionText)}
+            >
+              Add
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* End Session Confirmation */}
+      <Dialog open={showEndConfirm} onOpenChange={setShowEndConfirm}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="text-base">End session early?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            You've focused for {formatTime(getElapsedSeconds())} of your planned {formatTime(plannedDuration)}.
+            You'll still get to log your ending mood.
+          </p>
+          <div className="flex gap-2 justify-end pt-2">
+            <Button variant="outline" onClick={() => setShowEndConfirm(false)}>
+              Continue
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setShowEndConfirm(false)
+                handleEndEarly()
+              }}
+            >
+              End Session
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/components/focus/energy-selector.tsx
+++ b/components/focus/energy-selector.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import { Flame, Zap, Smile, CloudMoon, Moon } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+
+const ENERGY_LEVELS = [
+  { value: 1, label: 'Very Low', icon: Moon, color: 'text-muted-foreground' },
+  { value: 2, label: 'Low', icon: CloudMoon, color: 'text-blue-400' },
+  { value: 3, label: 'Medium', icon: Smile, color: 'text-amber-400' },
+  { value: 4, label: 'High', icon: Zap, color: 'text-orange-400' },
+  { value: 5, label: 'Very High', icon: Flame, color: 'text-red-400' },
+] as const
+
+interface EnergySelectorProps {
+  value: number | null
+  onChange: (value: number | null) => void
+  disabled?: boolean
+  size?: 'sm' | 'md'
+}
+
+export function EnergySelector({ value, onChange, disabled, size = 'md' }: EnergySelectorProps) {
+  const iconSize = size === 'sm' ? 'h-4 w-4' : 'h-5 w-5'
+  const btnSize = size === 'sm' ? 'h-8 w-8' : 'h-10 w-10'
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="flex items-center gap-1.5">
+        {ENERGY_LEVELS.map((level) => {
+          const Icon = level.icon
+          const isSelected = value === level.value
+          return (
+            <Tooltip key={level.value}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => onChange(isSelected ? null : level.value)}
+                  className={cn(
+                    'rounded-full flex items-center justify-center transition-all duration-200',
+                    btnSize,
+                    isSelected
+                      ? 'bg-primary/10 ring-2 ring-primary scale-110'
+                      : 'hover:bg-muted/60 hover:scale-105',
+                    disabled && 'opacity-50 cursor-not-allowed'
+                  )}
+                >
+                  <Icon className={cn(iconSize, isSelected ? level.color : 'text-muted-foreground/60')} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                {level.label}
+              </TooltipContent>
+            </Tooltip>
+          )
+        })}
+      </div>
+    </TooltipProvider>
+  )
+}
+
+export function EnergyBadge({ value, size = 'sm' }: { value: number; size?: 'sm' | 'md' }) {
+  const level = ENERGY_LEVELS.find((l) => l.value === value)
+  if (!level) return null
+
+  const Icon = level.icon
+  const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4'
+
+  return (
+    <span className={cn('inline-flex items-center gap-1 text-xs', level.color)}>
+      <Icon className={iconSize} />
+      <span className="text-muted-foreground">{level.label}</span>
+    </span>
+  )
+}
+
+export { ENERGY_LEVELS }

--- a/components/focus/focus-floating-widget.tsx
+++ b/components/focus/focus-floating-widget.tsx
@@ -126,10 +126,12 @@ export function FocusFloatingWidget() {
       const result = await endFocusSession({
         sessionId,
         actualDuration,
+        moodAfter: 3, // Default neutral mood when ending from mini widget
         metadata: {
           presetId: preferences.presetId,
           completed: reason === 'completed',
           endedReason: reason,
+          endedFromWidget: true,
         },
       })
 

--- a/components/focus/focus-history-client.tsx
+++ b/components/focus/focus-history-client.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { FocusHeatmapCalendar } from '@/components/focus/focus-heatmap-calendar'
+import { SessionCard } from '@/components/focus/session-card'
+import { getFocusSessionsPaginated } from '@/app/actions/focusSessions'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
+import { ChevronLeft, ChevronRight, ArrowUpDown } from 'lucide-react'
+import Link from 'next/link'
+import type { FocusSession } from '@/types/database'
+
+const PAGE_SIZE = 10
+
+export function FocusHistoryClient() {
+  const [sessions, setSessions] = useState<FocusSession[]>([])
+  const [page, setPage] = useState(0)
+  const [total, setTotal] = useState(0)
+  const [sortOrder, setSortOrder] = useState<'desc' | 'asc'>('desc')
+  const [isLoading, setIsLoading] = useState(true)
+
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const loadSessions = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const result = await getFocusSessionsPaginated(page, PAGE_SIZE, sortOrder)
+      if (result.data) {
+        setSessions(result.data.sessions)
+        setTotal(result.data.total)
+      }
+    } catch {
+      // handled
+    } finally {
+      setIsLoading(false)
+    }
+  }, [page, sortOrder])
+
+  useEffect(() => {
+    void loadSessions()
+  }, [loadSessions])
+
+  const handleSortToggle = useCallback(() => {
+    setSortOrder((prev) => (prev === 'desc' ? 'asc' : 'desc'))
+    setPage(0)
+  }, [])
+
+  return (
+    <div className="w-full max-w-3xl mx-auto space-y-8">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard/focus"
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Focus History</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {total} session{total !== 1 ? 's' : ''} recorded
+          </p>
+        </div>
+      </div>
+
+      {/* Calendar Heatmap */}
+      <div className="rounded-2xl border border-border/60 bg-card/50 p-5 shadow-sm">
+        <FocusHeatmapCalendar />
+      </div>
+
+      {/* Sessions List */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+            All Sessions
+          </h2>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 text-xs gap-1 text-muted-foreground"
+            onClick={handleSortToggle}
+          >
+            <ArrowUpDown className="h-3 w-3" />
+            {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-20 rounded-xl" />
+            ))}
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="rounded-xl border border-border/30 bg-card/20 p-8 text-center">
+            <p className="text-sm text-muted-foreground">No focus sessions found.</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {sessions.map((session) => (
+              <SessionCard key={session.session_id} session={session} />
+            ))}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2 pt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page === 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              className="h-8"
+            >
+              <ChevronLeft className="h-4 w-4 mr-1" />
+              Prev
+            </Button>
+            <span className="text-sm text-muted-foreground px-2">
+              {page + 1} / {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages - 1}
+              onClick={() => setPage((p) => p + 1)}
+              className="h-8"
+            >
+              Next
+              <ChevronRight className="h-4 w-4 ml-1" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/focus/focus-hub-client.tsx
+++ b/components/focus/focus-hub-client.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { FocusStarter } from '@/components/focus/focus-starter'
+import { ActiveTimer } from '@/components/focus/active-timer'
+import { SessionCompletion } from '@/components/focus/session-completion'
+import { SessionCard } from '@/components/focus/session-card'
+import { getFocusSessions } from '@/app/actions/focusSessions'
+import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
+import { History } from 'lucide-react'
+import Link from 'next/link'
+import type { FocusSession, InterruptionDetail } from '@/types/database'
+
+type FocusPhase = 'idle' | 'active' | 'completion'
+
+export function FocusHubClient() {
+  const [phase, setPhase] = useState<FocusPhase>('idle')
+  const [activeSession, setActiveSession] = useState<FocusSession | null>(null)
+  const [completionData, setCompletionData] = useState<{
+    actualDuration: number
+    interruptions: InterruptionDetail[]
+  } | null>(null)
+  const [recentSessions, setRecentSessions] = useState<FocusSession[]>([])
+  const [isLoadingRecent, setIsLoadingRecent] = useState(true)
+
+  const loadRecentSessions = useCallback(async () => {
+    setIsLoadingRecent(true)
+    try {
+      const result = await getFocusSessions(4)
+      if (result.data) {
+        setRecentSessions(result.data)
+      }
+    } catch {
+      // Non-critical
+    } finally {
+      setIsLoadingRecent(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadRecentSessions()
+  }, [loadRecentSessions])
+
+  const handleSessionStarted = useCallback((session: FocusSession) => {
+    setActiveSession(session)
+    setPhase('active')
+  }, [])
+
+  const handleSessionEnd = useCallback(
+    (actualDuration: number, interruptions: InterruptionDetail[]) => {
+      setCompletionData({ actualDuration, interruptions })
+      setPhase('completion')
+    },
+    []
+  )
+
+  const handleCompletionDone = useCallback(() => {
+    setPhase('idle')
+    setActiveSession(null)
+    setCompletionData(null)
+    void loadRecentSessions()
+  }, [loadRecentSessions])
+
+  // Active Timer
+  if (phase === 'active' && activeSession) {
+    return <ActiveTimer session={activeSession} onSessionEnd={handleSessionEnd} />
+  }
+
+  // Session Completion
+  if (phase === 'completion' && activeSession && completionData) {
+    return (
+      <SessionCompletion
+        session={activeSession}
+        actualDuration={completionData.actualDuration}
+        interruptions={completionData.interruptions}
+        onComplete={handleCompletionDone}
+      />
+    )
+  }
+
+  // Idle — Focus Hub
+  return (
+    <div className="w-full max-w-2xl mx-auto space-y-8">
+      {/* Page Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Focus</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Calm, intentional deep work
+          </p>
+        </div>
+        <Link
+          href="/dashboard/focus/history"
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium',
+            'text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors'
+          )}
+        >
+          <History className="h-4 w-4" />
+          History
+        </Link>
+      </div>
+
+      {/* Focus Starter Form */}
+      <FocusStarter onSessionStarted={handleSessionStarted} />
+
+      {/* Recent Sessions */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+            Recent Sessions
+          </h2>
+        </div>
+
+        {isLoadingRecent ? (
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 rounded-xl" />
+            ))}
+          </div>
+        ) : recentSessions.length === 0 ? (
+          <div className="rounded-xl border border-border/30 bg-card/20 p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No sessions yet. Start your first focus session above.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {recentSessions.map((session) => (
+              <SessionCard key={session.session_id} session={session} compact />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/focus/focus-starter.tsx
+++ b/components/focus/focus-starter.tsx
@@ -1,0 +1,358 @@
+'use client'
+
+import { useState, useCallback, useMemo } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import { EnergySelector } from '@/components/focus/energy-selector'
+import { useTasks } from '@/hooks/use-tasks'
+import { startFocusSession } from '@/app/actions/focusSessions'
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+import {
+  Search,
+  Play,
+  ChevronDown,
+  X,
+  Loader2,
+} from 'lucide-react'
+import type { Task, FocusSession } from '@/types/database'
+
+const DURATION_CHIPS = [25, 35, 45, 60, 90] as const
+const TAG_OPTIONS = ['Deep Work', 'Creative', 'Admin', 'Learning', 'Review', 'Other'] as const
+
+interface FocusStarterProps {
+  onSessionStarted: (session: FocusSession) => void
+}
+
+export function FocusStarter({ onSessionStarted }: FocusStarterProps) {
+  const { data: allTasks = [], isLoading: tasksLoading } = useTasks()
+
+  // Form state
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
+  const [customTaskText, setCustomTaskText] = useState('')
+  const [isCustomTask, setIsCustomTask] = useState(false)
+  const [duration, setDuration] = useState(35)
+  const [isCustomDuration, setIsCustomDuration] = useState(false)
+  const [customDurationInput, setCustomDurationInput] = useState('')
+  const [energyStart, setEnergyStart] = useState<number | null>(null)
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [notes, setNotes] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Task combobox state
+  const [taskSearchOpen, setTaskSearchOpen] = useState(false)
+  const [taskSearchQuery, setTaskSearchQuery] = useState('')
+
+  // Filter today's pending tasks
+  const pendingTasks = useMemo(() => {
+    return allTasks.filter(
+      (task: Task) => task.status === 'pending' || task.status === 'in_progress'
+    )
+  }, [allTasks])
+
+  const filteredTasks = useMemo(() => {
+    if (!taskSearchQuery.trim()) return pendingTasks
+    const q = taskSearchQuery.toLowerCase()
+    return pendingTasks.filter((task: Task) => task.title.toLowerCase().includes(q))
+  }, [pendingTasks, taskSearchQuery])
+
+  const selectedTask = useMemo(
+    () => pendingTasks.find((t: Task) => t.task_id === selectedTaskId),
+    [pendingTasks, selectedTaskId]
+  )
+
+  const toggleTag = useCallback((tag: string) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    )
+  }, [])
+
+  const handleSelectTask = useCallback((task: Task) => {
+    setSelectedTaskId(task.task_id)
+    setIsCustomTask(false)
+    setCustomTaskText('')
+    setTaskSearchOpen(false)
+    setTaskSearchQuery('')
+  }, [])
+
+  const handleSelectCustom = useCallback(() => {
+    setSelectedTaskId(null)
+    setIsCustomTask(true)
+    setTaskSearchOpen(false)
+    setTaskSearchQuery('')
+  }, [])
+
+  const clearSelection = useCallback(() => {
+    setSelectedTaskId(null)
+    setIsCustomTask(false)
+    setCustomTaskText('')
+  }, [])
+
+  const handleStartSession = useCallback(async () => {
+    setIsSubmitting(true)
+    try {
+      const result = await startFocusSession({
+        taskId: selectedTaskId,
+        customTaskText: isCustomTask ? customTaskText.trim() || null : null,
+        plannedDuration: duration * 60,
+        energyStart,
+        tags: selectedTags.length > 0 ? selectedTags : null,
+        metadata: {
+          notes: notes.trim() || null,
+        },
+      })
+
+      if (result.error || !result.data) {
+        throw new Error(result.error ?? 'Could not start focus session')
+      }
+
+      onSessionStarted(result.data)
+    } catch (error) {
+      console.error('Failed to start focus session:', error)
+      toast.error('We could not start the focus session.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [selectedTaskId, isCustomTask, customTaskText, duration, energyStart, selectedTags, notes, onSessionStarted])
+
+  return (
+    <div className="w-full space-y-6">
+      {/* Start Session Card */}
+      <div className="rounded-2xl border border-border/60 bg-card/50 p-6 md:p-8 space-y-6 shadow-sm">
+        {/* Task Selector */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-foreground">What will you focus on?</label>
+
+          {/* Selected task display */}
+          {(selectedTask || isCustomTask) && (
+            <div className="flex items-center gap-2 rounded-xl bg-primary/5 border border-primary/20 px-4 py-3">
+              <div className="flex-1 min-w-0">
+                {selectedTask ? (
+                  <span className="text-sm font-medium truncate block">{selectedTask.title}</span>
+                ) : (
+                  <Input
+                    value={customTaskText}
+                    onChange={(e) => setCustomTaskText(e.target.value)}
+                    placeholder="What are you working on?"
+                    className="border-0 bg-transparent p-0 h-auto text-sm font-medium shadow-none focus-visible:ring-0"
+                    maxLength={120}
+                    autoFocus
+                  />
+                )}
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 rounded-full text-muted-foreground hover:text-foreground shrink-0"
+                onClick={clearSelection}
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          )}
+
+          {/* Task search combobox */}
+          {!selectedTask && !isCustomTask && (
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setTaskSearchOpen(!taskSearchOpen)}
+                className={cn(
+                  'w-full flex items-center gap-2 rounded-xl border border-border/60 bg-background px-4 py-3 text-left text-sm transition-colors',
+                  'hover:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/30',
+                  taskSearchOpen && 'ring-2 ring-primary/30 border-primary/40'
+                )}
+              >
+                <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+                <span className="text-muted-foreground">Search tasks or enter custom…</span>
+                <ChevronDown className={cn('h-4 w-4 text-muted-foreground ml-auto shrink-0 transition-transform', taskSearchOpen && 'rotate-180')} />
+              </button>
+
+              {taskSearchOpen && (
+                <div className="absolute z-50 mt-1 w-full rounded-xl border border-border bg-popover shadow-lg animate-in fade-in-0 zoom-in-95 duration-150">
+                  <div className="p-2">
+                    <Input
+                      value={taskSearchQuery}
+                      onChange={(e) => setTaskSearchQuery(e.target.value)}
+                      placeholder="Search tasks…"
+                      className="h-9 text-sm"
+                      autoFocus
+                    />
+                  </div>
+
+                  <div className="max-h-48 overflow-y-auto px-1 pb-1">
+                    {/* Custom focus option */}
+                    <button
+                      type="button"
+                      onClick={handleSelectCustom}
+                      className="w-full flex items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm hover:bg-muted/60 transition-colors"
+                    >
+                      <span className="text-primary font-medium">✦ Custom Focus Session</span>
+                    </button>
+
+                    {tasksLoading ? (
+                      <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+                        <Loader2 className="h-4 w-4 animate-spin mx-auto mb-1" />
+                        Loading tasks…
+                      </div>
+                    ) : filteredTasks.length === 0 ? (
+                      <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+                        No matching tasks
+                      </div>
+                    ) : (
+                      filteredTasks.map((task: Task) => (
+                        <button
+                          key={task.task_id}
+                          type="button"
+                          onClick={() => handleSelectTask(task)}
+                          className={cn(
+                            'w-full flex items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm hover:bg-muted/60 transition-colors',
+                            selectedTaskId === task.task_id && 'bg-primary/5'
+                          )}
+                        >
+                          <span className="truncate">{task.title}</span>
+                          {task.priority === 'high' && (
+                            <Badge variant="outline" className="text-[10px] px-1.5 py-0 shrink-0 text-destructive border-destructive/30">
+                              High
+                            </Badge>
+                          )}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Duration Chips */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-foreground">Duration</label>
+          <div className="flex flex-wrap items-center gap-2">
+            {DURATION_CHIPS.map((d) => (
+              <button
+                key={d}
+                type="button"
+                onClick={() => {
+                  setDuration(d)
+                  setIsCustomDuration(false)
+                  setCustomDurationInput('')
+                }}
+                className={cn(
+                  'px-4 py-2 rounded-full text-sm font-medium transition-all duration-200',
+                  !isCustomDuration && duration === d
+                    ? 'bg-primary text-primary-foreground shadow-sm'
+                    : 'bg-muted/50 text-foreground hover:bg-muted border border-border/40'
+                )}
+              >
+                {d}m
+              </button>
+            ))}
+
+            {/* Custom duration chip + inline input */}
+            {isCustomDuration ? (
+              <div className="flex items-center gap-1.5 rounded-full bg-primary text-primary-foreground shadow-sm pl-3 pr-1 py-1">
+                <Input
+                  type="number"
+                  min={1}
+                  max={180}
+                  value={customDurationInput}
+                  onChange={(e) => {
+                    const val = e.target.value
+                    setCustomDurationInput(val)
+                    const num = parseInt(val, 10)
+                    if (num >= 1 && num <= 180) setDuration(num)
+                  }}
+                  placeholder="min"
+                  className="h-7 w-14 border-0 bg-primary-foreground/20 text-primary-foreground placeholder:text-primary-foreground/50 text-sm text-center rounded-full px-2 shadow-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  autoFocus
+                />
+                <span className="text-xs font-medium pr-1">min</span>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setIsCustomDuration(true)}
+                className="px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 bg-muted/50 text-foreground hover:bg-muted border border-dashed border-border/60"
+              >
+                Custom
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Starting Energy */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-muted-foreground">
+            Starting Energy
+            <span className="text-xs ml-1">(optional)</span>
+          </label>
+          <EnergySelector value={energyStart} onChange={setEnergyStart} />
+        </div>
+
+        {/* Tags */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-muted-foreground">
+            Tags
+            <span className="text-xs ml-1">(optional)</span>
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {TAG_OPTIONS.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleTag(tag)}
+                className={cn(
+                  'px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-200',
+                  selectedTags.includes(tag)
+                    ? 'bg-accent/20 text-accent-foreground border border-accent/40'
+                    : 'bg-muted/30 text-muted-foreground hover:bg-muted/60 border border-transparent'
+                )}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Notes */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-muted-foreground">
+            Notes
+            <span className="text-xs ml-1">(optional)</span>
+          </label>
+          <Textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Any intentions for this session…"
+            className="min-h-[60px] resize-none text-sm bg-background/50"
+            maxLength={500}
+          />
+        </div>
+
+        {/* Start Button */}
+        <Button
+          size="lg"
+          className="w-full h-12 rounded-xl text-base font-semibold gap-2"
+          disabled={isSubmitting}
+          onClick={handleStartSession}
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Starting…
+            </>
+          ) : (
+            <>
+              <Play className="h-5 w-5" />
+              Start Focus Session
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/focus/mood-selector.tsx
+++ b/components/focus/mood-selector.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+const MOOD_LEVELS = [
+  { value: 1, emoji: '😔', label: 'Very Low' },
+  { value: 2, emoji: '😕', label: 'Low' },
+  { value: 3, emoji: '😐', label: 'Neutral' },
+  { value: 4, emoji: '🙂', label: 'Good' },
+  { value: 5, emoji: '😊', label: 'Great' },
+] as const
+
+interface MoodSelectorProps {
+  value: number | null
+  onChange: (value: number) => void
+  disabled?: boolean
+  size?: 'sm' | 'md' | 'lg'
+  required?: boolean
+}
+
+export function MoodSelector({ value, onChange, disabled, size = 'md', required }: MoodSelectorProps) {
+  const emojiSize = {
+    sm: 'text-lg',
+    md: 'text-2xl',
+    lg: 'text-3xl',
+  }[size]
+
+  const btnSize = {
+    sm: 'h-9 w-9',
+    md: 'h-12 w-12',
+    lg: 'h-14 w-14',
+  }[size]
+
+  return (
+    <div className="flex items-center gap-2">
+      {MOOD_LEVELS.map((mood) => {
+        const isSelected = value === mood.value
+        return (
+          <button
+            key={mood.value}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(mood.value)}
+            className={cn(
+              'rounded-full flex items-center justify-center transition-all duration-200',
+              btnSize,
+              isSelected
+                ? 'bg-primary/10 ring-2 ring-primary scale-110'
+                : 'hover:bg-muted/60 hover:scale-105',
+              disabled && 'opacity-50 cursor-not-allowed'
+            )}
+            aria-label={mood.label}
+          >
+            <span className={emojiSize}>{mood.emoji}</span>
+          </button>
+        )
+      })}
+      {required && !value && (
+        <span className="text-xs text-destructive ml-1">Required</span>
+      )}
+    </div>
+  )
+}
+
+export function MoodBadge({ value }: { value: number }) {
+  const mood = MOOD_LEVELS.find((m) => m.value === value)
+  if (!mood) return null
+
+  return (
+    <span className="inline-flex items-center gap-1 text-sm">
+      <span>{mood.emoji}</span>
+      <span className="text-xs text-muted-foreground">{mood.label}</span>
+    </span>
+  )
+}
+
+export function MoodDelta({ before, after }: { before: number; after: number }) {
+  const delta = after - before
+  const color = delta > 0 ? 'text-green-500' : delta < 0 ? 'text-red-400' : 'text-muted-foreground'
+
+  return (
+    <span className={cn('inline-flex items-center gap-1.5 text-sm', color)}>
+      <MoodBadge value={before} />
+      <span className="text-muted-foreground">→</span>
+      <MoodBadge value={after} />
+      {delta !== 0 && (
+        <span className="text-xs font-medium">
+          ({delta > 0 ? '+' : ''}{delta})
+        </span>
+      )}
+    </span>
+  )
+}
+
+export { MOOD_LEVELS }

--- a/components/focus/session-card.tsx
+++ b/components/focus/session-card.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { formatDuration } from '@/lib/focus-mode'
+import { cn } from '@/lib/utils'
+import { Clock, AlertCircle } from 'lucide-react'
+import { EnergyBadge } from '@/components/focus/energy-selector'
+import type { FocusSession } from '@/types/database'
+import Link from 'next/link'
+
+interface SessionCardProps {
+  session: FocusSession
+  compact?: boolean
+}
+
+export function SessionCard({ session, compact = false }: SessionCardProps) {
+  const taskLabel =
+    session.custom_task_text?.trim() ||
+    session.tasks?.title ||
+    (session.metadata as Record<string, unknown>)?.name as string ||
+    'Focus Session'
+  const actualDuration = session.actual_duration ?? session.planned_duration
+  const completed = Boolean(session.ended_at) && actualDuration >= session.planned_duration
+  const interruptions = session.interruptions ?? 0
+  const tags = session.tags ?? []
+
+  return (
+    <Link
+      href={`/dashboard/focus/${session.session_id}`}
+      className={cn(
+        'block rounded-xl border border-border/40 bg-card/30 p-4 transition-all duration-200',
+        'hover:bg-card/60 hover:border-border/60 hover:shadow-sm',
+        compact && 'p-3'
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0 space-y-1">
+          <p className={cn(
+            'font-medium text-foreground truncate',
+            compact ? 'text-sm' : 'text-base'
+          )}>
+            {taskLabel}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {new Date(session.started_at).toLocaleDateString(undefined, {
+              weekday: 'short',
+              month: 'short',
+              day: 'numeric',
+              hour: 'numeric',
+              minute: '2-digit',
+            })}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <span className={cn(
+            'flex items-center gap-1 text-sm font-medium',
+            completed ? 'text-foreground' : 'text-muted-foreground'
+          )}>
+            <Clock className="h-3.5 w-3.5" />
+            {formatDuration(actualDuration)}
+          </span>
+          <span
+            className={cn(
+              'h-2 w-2 rounded-full shrink-0',
+              completed ? 'bg-primary' : 'bg-muted-foreground/40'
+            )}
+          />
+        </div>
+      </div>
+
+      {!compact && (
+        <div className="mt-2 flex items-center gap-3 flex-wrap">
+          {/* Mood delta */}
+          {session.mood_before != null && session.mood_after != null && (
+            <span className="text-xs text-muted-foreground">
+              Mood: {getMoodEmoji(session.mood_before)} → {getMoodEmoji(session.mood_after)}
+            </span>
+          )}
+
+          {/* Energy delta */}
+          {session.energy_start != null && session.energy_end != null && (
+            <span className="text-xs text-muted-foreground">
+              Energy: {session.energy_start} → {session.energy_end}
+            </span>
+          )}
+          {session.energy_start != null && session.energy_end == null && (
+            <EnergyBadge value={session.energy_start} size="sm" />
+          )}
+
+          {/* Interruptions */}
+          {interruptions > 0 && (
+            <span className="flex items-center gap-0.5 text-xs text-muted-foreground">
+              <AlertCircle className="h-3 w-3" />
+              {interruptions}
+            </span>
+          )}
+
+          {/* Tags */}
+          {tags.length > 0 && (
+            <div className="flex gap-1 flex-wrap">
+              {tags.slice(0, 3).map((tag) => (
+                <span
+                  key={tag}
+                  className="text-[10px] px-1.5 py-0.5 rounded-full bg-accent/10 text-accent-foreground"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </Link>
+  )
+}
+
+function getMoodEmoji(value: number): string {
+  const map: Record<number, string> = {
+    1: '😔',
+    2: '😕',
+    3: '😐',
+    4: '🙂',
+    5: '😊',
+  }
+  return map[value] ?? '😐'
+}

--- a/components/focus/session-completion.tsx
+++ b/components/focus/session-completion.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { MoodSelector } from '@/components/focus/mood-selector'
+import { EnergySelector } from '@/components/focus/energy-selector'
+import { endFocusSession } from '@/app/actions/focusSessions'
+import { formatDuration } from '@/lib/focus-mode'
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+import { Check, Loader2 } from 'lucide-react'
+import type { FocusSession, InterruptionDetail } from '@/types/database'
+
+interface SessionCompletionProps {
+  session: FocusSession
+  actualDuration: number
+  interruptions: InterruptionDetail[]
+  onComplete: () => void
+}
+
+export function SessionCompletion({
+  session,
+  actualDuration,
+  interruptions,
+  onComplete,
+}: SessionCompletionProps) {
+  const [moodAfter, setMoodAfter] = useState<number | null>(null)
+  const [energyEnd, setEnergyEnd] = useState<number | null>(session.energy_start)
+  const [reflection, setReflection] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+
+  const taskLabel = session.custom_task_text || session.tasks?.title || 'Focus Session'
+  const completed = actualDuration >= session.planned_duration
+
+  const handleSave = useCallback(async () => {
+    if (moodAfter === null) {
+      toast.error('Please select your ending mood.')
+      return
+    }
+
+    setIsSaving(true)
+    try {
+      const existingMetadata = (session.metadata as Record<string, unknown>) ?? {}
+
+      const result = await endFocusSession({
+        sessionId: session.session_id,
+        actualDuration,
+        moodAfter,
+        energyEnd,
+        interruptions: interruptions.length,
+        interruptionDetails: interruptions,
+        metadata: {
+          ...existingMetadata,
+          reflection: reflection.trim() || null,
+          completed,
+        },
+      })
+
+      if (result.error) {
+        throw new Error(result.error)
+      }
+
+      toast.success('Session saved. Well done.')
+      onComplete()
+    } catch (error) {
+      console.error('Failed to save session:', error)
+      toast.error('We could not save the session.')
+    } finally {
+      setIsSaving(false)
+    }
+  }, [moodAfter, energyEnd, reflection, session, actualDuration, interruptions, completed, onComplete])
+
+  return (
+    <div className="fixed inset-0 z-50 bg-background flex items-center justify-center px-6 animate-in fade-in-0 duration-300">
+      <div className="w-full max-w-md space-y-8">
+        {/* Summary Header */}
+        <div className="text-center space-y-2">
+          <div className={cn(
+            'mx-auto w-16 h-16 rounded-full flex items-center justify-center mb-4',
+            completed ? 'bg-primary/10' : 'bg-muted/40'
+          )}>
+            <Check className={cn('h-8 w-8', completed ? 'text-primary' : 'text-muted-foreground')} />
+          </div>
+          <h2 className="text-xl font-bold tracking-tight">
+            {completed ? 'Session Complete' : 'Session Ended'}
+          </h2>
+          <p className="text-sm text-muted-foreground truncate">{taskLabel}</p>
+          <p className="text-2xl font-bold text-primary">
+            {formatDuration(actualDuration)}
+          </p>
+          {interruptions.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {interruptions.length} interruption{interruptions.length !== 1 ? 's' : ''}
+            </p>
+          )}
+        </div>
+
+        {/* Ending Mood */}
+        <div className="space-y-3">
+          <label className="text-sm font-medium text-foreground">
+            How are you feeling?
+            <span className="text-destructive ml-0.5">*</span>
+          </label>
+          <MoodSelector value={moodAfter} onChange={setMoodAfter} size="md" required />
+        </div>
+
+        {/* Ending Energy */}
+        <div className="space-y-3">
+          <label className="text-sm font-medium text-muted-foreground">
+            Ending Energy
+            <span className="text-xs ml-1">(optional)</span>
+          </label>
+          <EnergySelector value={energyEnd} onChange={setEnergyEnd} />
+        </div>
+
+        {/* Reflection */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-muted-foreground">
+            What helped or distracted you?
+            <span className="text-xs ml-1">(optional)</span>
+          </label>
+          <Textarea
+            value={reflection}
+            onChange={(e) => setReflection(e.target.value)}
+            placeholder="Brief reflection…"
+            className="min-h-[60px] resize-none text-sm"
+            maxLength={500}
+          />
+        </div>
+
+        {/* Save Button */}
+        <Button
+          size="lg"
+          className="w-full h-12 rounded-xl text-base font-semibold"
+          disabled={isSaving || moodAfter === null}
+          onClick={handleSave}
+        >
+          {isSaving ? (
+            <>
+              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              Saving…
+            </>
+          ) : (
+            'Save Session'
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/focus/session-detail-client.tsx
+++ b/components/focus/session-detail-client.tsx
@@ -1,0 +1,377 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { getFocusSession, updateFocusSessionNotes } from '@/app/actions/focusSessions'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { MoodBadge, MoodDelta } from '@/components/focus/mood-selector'
+import { EnergyBadge, ENERGY_LEVELS } from '@/components/focus/energy-selector'
+import { formatDuration, formatTime } from '@/lib/focus-mode'
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+import {
+  ChevronLeft,
+  Clock,
+  CalendarDays,
+  AlertCircle,
+  Tag,
+  Edit3,
+  Save,
+  Loader2,
+  Bell,
+  Brain,
+  Smartphone,
+  Users,
+  HelpCircle,
+} from 'lucide-react'
+import Link from 'next/link'
+import type { FocusSession, InterruptionDetail } from '@/types/database'
+
+const INTERRUPTION_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  notification: Bell,
+  mind_wandering: Brain,
+  phone: Smartphone,
+  external: Users,
+  other: HelpCircle,
+}
+
+interface SessionDetailClientProps {
+  sessionId: number
+}
+
+export function SessionDetailClient({ sessionId }: SessionDetailClientProps) {
+  const [session, setSession] = useState<FocusSession | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Notes editing
+  const [isEditingNotes, setIsEditingNotes] = useState(false)
+  const [notesText, setNotesText] = useState('')
+  const [isSavingNotes, setIsSavingNotes] = useState(false)
+
+  useEffect(() => {
+    async function load() {
+      setIsLoading(true)
+      try {
+        const result = await getFocusSession(sessionId)
+        if (result.error) throw new Error(result.error)
+        setSession(result.data ?? null)
+
+        // Initialize notes
+        const metadata = result.data?.metadata as Record<string, unknown> | null
+        const existingNotes = metadata?.notes as string | null
+        const reflection = metadata?.reflection as string | null
+        setNotesText(existingNotes || reflection || '')
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load session')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    void load()
+  }, [sessionId])
+
+  const handleSaveNotes = useCallback(async () => {
+    if (!session) return
+    setIsSavingNotes(true)
+    try {
+      const existingMetadata = (session.metadata as Record<string, unknown>) ?? {}
+      const result = await updateFocusSessionNotes(session.session_id, {
+        ...existingMetadata,
+        notes: notesText.trim() || null,
+        reflection: notesText.trim() || null,
+      })
+
+      if (result.error) throw new Error(result.error)
+      setSession(result.data ?? session)
+      setIsEditingNotes(false)
+      toast.success('Notes updated.')
+    } catch {
+      toast.error('Could not save notes.')
+    } finally {
+      setIsSavingNotes(false)
+    }
+  }, [session, notesText])
+
+  if (isLoading) {
+    return (
+      <div className="w-full max-w-2xl mx-auto space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-32 rounded-2xl" />
+        <Skeleton className="h-48 rounded-2xl" />
+        <Skeleton className="h-24 rounded-2xl" />
+      </div>
+    )
+  }
+
+  if (error || !session) {
+    return (
+      <div className="w-full max-w-2xl mx-auto text-center py-16">
+        <p className="text-destructive text-sm">{error ?? 'Session not found.'}</p>
+        <Link href="/dashboard/focus/history" className="text-sm text-primary hover:underline mt-2 inline-block">
+          Back to history
+        </Link>
+      </div>
+    )
+  }
+
+  const taskLabel = session.custom_task_text?.trim() || session.tasks?.title || 'Focus Session'
+  const actualDuration = session.actual_duration ?? session.planned_duration
+  const completed = Boolean(session.ended_at) && actualDuration >= session.planned_duration
+  const interruptions = (session.interruption_details as InterruptionDetail[]) ?? []
+  const tags = session.tags ?? []
+  const metadata = (session.metadata as Record<string, unknown>) ?? {}
+  const reflection = (metadata.reflection as string) || (metadata.notes as string) || ''
+
+  return (
+    <div className="w-full max-w-2xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard/focus/history"
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Link>
+        <div className="flex-1 min-w-0">
+          <h1 className="text-xl font-bold tracking-tight truncate">{taskLabel}</h1>
+          <p className="text-sm text-muted-foreground flex items-center gap-1.5 mt-0.5">
+            <CalendarDays className="h-3.5 w-3.5" />
+            {new Date(session.started_at).toLocaleDateString(undefined, {
+              weekday: 'long',
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+              hour: 'numeric',
+              minute: '2-digit',
+            })}
+          </p>
+        </div>
+        <div
+          className={cn(
+            'px-3 py-1 rounded-full text-xs font-medium',
+            completed
+              ? 'bg-primary/10 text-primary'
+              : 'bg-muted text-muted-foreground'
+          )}
+        >
+          {completed ? 'Completed' : 'Ended Early'}
+        </div>
+      </div>
+
+      {/* Duration Card */}
+      <div className="rounded-2xl border border-border/60 bg-card/50 p-6 shadow-sm">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+          <DetailItem
+            label="Actual Duration"
+            value={formatDuration(actualDuration)}
+            icon={<Clock className="h-4 w-4 text-primary" />}
+            highlight
+          />
+          <DetailItem
+            label="Planned Duration"
+            value={formatDuration(session.planned_duration)}
+            icon={<Clock className="h-4 w-4 text-muted-foreground" />}
+          />
+          {session.ended_at && (
+            <DetailItem
+              label="Ended At"
+              value={new Date(session.ended_at).toLocaleTimeString(undefined, {
+                hour: 'numeric',
+                minute: '2-digit',
+              })}
+              icon={<CalendarDays className="h-4 w-4 text-muted-foreground" />}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Mood & Energy Card */}
+      {(session.mood_before != null || session.mood_after != null || session.energy_start != null || session.energy_end != null) && (
+        <div className="rounded-2xl border border-border/60 bg-card/50 p-6 shadow-sm space-y-4">
+          <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+            Well-being
+          </h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {/* Mood */}
+            {session.mood_before != null && session.mood_after != null && (
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">Mood</p>
+                <MoodDelta before={session.mood_before} after={session.mood_after} />
+              </div>
+            )}
+            {session.mood_before != null && session.mood_after == null && (
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">Mood Before</p>
+                <MoodBadge value={session.mood_before} />
+              </div>
+            )}
+            {session.mood_before == null && session.mood_after != null && (
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">Mood After</p>
+                <MoodBadge value={session.mood_after} />
+              </div>
+            )}
+
+            {/* Energy */}
+            {session.energy_start != null && session.energy_end != null && (
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">Energy</p>
+                <div className="flex items-center gap-1.5">
+                  <EnergyBadge value={session.energy_start} />
+                  <span className="text-muted-foreground text-xs">→</span>
+                  <EnergyBadge value={session.energy_end} />
+                </div>
+              </div>
+            )}
+            {session.energy_start != null && session.energy_end == null && (
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">Starting Energy</p>
+                <EnergyBadge value={session.energy_start} />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Interruptions Card */}
+      {interruptions.length > 0 && (
+        <div className="rounded-2xl border border-border/60 bg-card/50 p-6 shadow-sm space-y-3">
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-4 w-4 text-muted-foreground" />
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+              Interruptions ({interruptions.length})
+            </h3>
+          </div>
+          <div className="space-y-2">
+            {interruptions.map((interruption, i) => {
+              const IconComponent = INTERRUPTION_ICONS[interruption.type] ?? HelpCircle
+              return (
+                <div
+                  key={i}
+                  className="flex items-center gap-3 rounded-lg bg-muted/20 px-3 py-2"
+                >
+                  <IconComponent className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <span className="text-sm capitalize">
+                    {interruption.label || interruption.type.replace('_', ' ')}
+                  </span>
+                  <span className="text-xs text-muted-foreground ml-auto">
+                    {new Date(interruption.timestamp).toLocaleTimeString(undefined, {
+                      hour: 'numeric',
+                      minute: '2-digit',
+                    })}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Tags */}
+      {tags.length > 0 && (
+        <div className="rounded-2xl border border-border/60 bg-card/50 p-6 shadow-sm space-y-3">
+          <div className="flex items-center gap-2">
+            <Tag className="h-4 w-4 text-muted-foreground" />
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">Tags</h3>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <Badge key={tag} variant="secondary" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Notes / Reflection */}
+      <div className="rounded-2xl border border-border/60 bg-card/50 p-6 shadow-sm space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+            Notes & Reflection
+          </h3>
+          {!isEditingNotes && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs gap-1 text-muted-foreground"
+              onClick={() => {
+                setNotesText(reflection)
+                setIsEditingNotes(true)
+              }}
+            >
+              <Edit3 className="h-3 w-3" />
+              Edit
+            </Button>
+          )}
+        </div>
+
+        {isEditingNotes ? (
+          <div className="space-y-2">
+            <Textarea
+              value={notesText}
+              onChange={(e) => setNotesText(e.target.value)}
+              placeholder="Add your notes or reflection…"
+              className="min-h-[80px] resize-none text-sm"
+              maxLength={1000}
+              autoFocus
+            />
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsEditingNotes(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                disabled={isSavingNotes}
+                onClick={handleSaveNotes}
+                className="gap-1"
+              >
+                {isSavingNotes ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Save className="h-3 w-3" />
+                )}
+                Save
+              </Button>
+            </div>
+          </div>
+        ) : reflection ? (
+          <p className="text-sm text-foreground whitespace-pre-wrap">{reflection}</p>
+        ) : (
+          <p className="text-sm text-muted-foreground italic">No notes added.</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DetailItem({
+  label,
+  value,
+  icon,
+  highlight = false,
+}: {
+  label: string
+  value: string
+  icon: React.ReactNode
+  highlight?: boolean
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+        {icon}
+        {label}
+      </p>
+      <p className={cn('text-lg font-semibold', highlight ? 'text-primary' : 'text-foreground')}>
+        {value}
+      </p>
+    </div>
+  )
+}

--- a/supabase/migrations/20260507_focus_sessions_v2.sql
+++ b/supabase/migrations/20260507_focus_sessions_v2.sql
@@ -1,0 +1,33 @@
+-- Migration: Add Focus Sessions V2 columns
+-- Adds mood_before, mood_after, energy_start, energy_end, 
+-- interruption_details, custom_task_text, and tags columns
+
+-- Add mood tracking columns
+ALTER TABLE public.focus_sessions
+  ADD COLUMN IF NOT EXISTS mood_before smallint NULL CHECK (mood_before BETWEEN 1 AND 5),
+  ADD COLUMN IF NOT EXISTS mood_after smallint NULL CHECK (mood_after BETWEEN 1 AND 5);
+
+-- Add energy tracking columns
+ALTER TABLE public.focus_sessions
+  ADD COLUMN IF NOT EXISTS energy_start smallint NULL CHECK (energy_start BETWEEN 1 AND 5),
+  ADD COLUMN IF NOT EXISTS energy_end smallint NULL CHECK (energy_end BETWEEN 1 AND 5);
+
+-- Add interruption details JSONB column (array of interruption objects)
+ALTER TABLE public.focus_sessions
+  ADD COLUMN IF NOT EXISTS interruption_details jsonb NULL DEFAULT '[]'::jsonb;
+
+-- Add custom task text for sessions not linked to a task
+ALTER TABLE public.focus_sessions
+  ADD COLUMN IF NOT EXISTS custom_task_text text NULL;
+
+-- Add tags for session categorization
+ALTER TABLE public.focus_sessions
+  ADD COLUMN IF NOT EXISTS tags text[] NULL;
+
+-- Create index on started_at for efficient date range queries
+CREATE INDEX IF NOT EXISTS idx_focus_sessions_started_at 
+  ON public.focus_sessions (user_id, started_at DESC);
+
+-- Create index on tags for filtering (GIN index for array containment)
+CREATE INDEX IF NOT EXISTS idx_focus_sessions_tags 
+  ON public.focus_sessions USING gin (tags);

--- a/types/database.ts
+++ b/types/database.ts
@@ -216,9 +216,42 @@ export interface FocusSession {
   planned_duration: number
   actual_duration: number | null
   interruptions: number | null
+  mood_before: number | null
+  mood_after: number | null
+  energy_start: number | null
+  energy_end: number | null
   started_at: string
   ended_at: string | null
+  interruption_details: InterruptionDetail[] | null
+  custom_task_text: string | null
+  tags: string[] | null
   metadata: Record<string, unknown> | null
   created_at: string | null
   tasks?: Pick<Task, 'task_id' | 'title' | 'status' | 'priority'> | null
+}
+
+export interface InterruptionDetail {
+  type: 'notification' | 'mind_wandering' | 'phone' | 'external' | 'other'
+  label?: string
+  timestamp: string
+}
+
+export interface StartFocusSessionInput {
+  taskId?: string | null
+  customTaskText?: string | null
+  plannedDuration: number
+  energyStart?: number | null
+  moodBefore?: number | null
+  tags?: string[] | null
+  metadata?: Record<string, unknown>
+}
+
+export interface EndFocusSessionInput {
+  sessionId: number
+  actualDuration: number
+  moodAfter: number
+  energyEnd?: number | null
+  interruptions?: number
+  interruptionDetails?: InterruptionDetail[]
+  metadata?: Record<string, unknown>
 }


### PR DESCRIPTION
Introduce a full-featured Focus experience: add Focus Hub, Starter, Active Timer, Session Completion, History, Session Detail pages and loading states. New client components include energy/mood selectors, interruption logging, session cards, heatmap calendar, floating widget tweaks, and paginated history UI. Server actions expanded in app/actions/focusSessions.ts: common SELECT fragment, getFocusSession, paginated fetch, start/update/end session signatures extended (mood, energy, interruption details, custom task text, tags), and updateFocusSessionNotes; improved update handling and error responses. Sidebar navigation updated to expose Focus -> Session/History, minor focus-timer tweak for mood default, types updated and a DB migration (20260507_focus_sessions_v2.sql) added for the new fields.