### PR TITLE
Add ML health endpoint and focus completion flow

### DIFF
--- a/app/actions/ml.ts
+++ b/app/actions/ml.ts
@@ -5,7 +5,6 @@ import type { SentimentRequest, SentimentResponse } from "@/lib/journal-sentimen
 
 const ML_ENDPOINT = process.env.ML_ENDPOINT;
 const API_SECRET = process.env.API_SECRET || "";
-const ML_HEALTH_TIMEOUT_MS = Number(process.env.ML_HEALTH_TIMEOUT_MS || "2500");
 
 export async function fetchPredictionAction(
   input: HabitPredictionInput
@@ -57,36 +56,5 @@ export async function fetchSentimentAction(
   } catch (error) {
     console.error("[JournalSentiment] Failed to fetch analysis:", error);
     return null;
-  }
-}
-
-export async function warmServicesAction(): Promise<boolean> {
-  if (!ML_ENDPOINT) {
-    console.warn("[WarmServices] No ML_ENDPOINT configured");
-    return false;
-  }
-
-  try {
-    // Keep warm-up bounded so ML cold starts never hold app startup work.
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), ML_HEALTH_TIMEOUT_MS);
-
-    try {
-      const response = await fetch(`${ML_ENDPOINT}/v1/health`, {
-        method: "GET",
-        headers: {
-          "x-api-secret": API_SECRET,
-        },
-        cache: "no-store",
-        signal: controller.signal,
-      });
-
-      return response.ok;
-    } finally {
-      clearTimeout(timeout);
-    }
-  } catch (error) {
-    console.warn("[WarmServices] Failed to reach ML services:", error);
-    return false;
   }
 }

--- a/app/api/ai/health/route.ts
+++ b/app/api/ai/health/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+
+const ML_ENDPOINT = process.env.ML_ENDPOINT;
+const API_SECRET = process.env.API_SECRET || "";
+const ML_WARMUP_TIMEOUT_MS = Number(process.env.ML_WARMUP_TIMEOUT_MS || "90000");
+
+export async function GET() {
+  if (!ML_ENDPOINT) {
+    return NextResponse.json(
+      { status: "error", reason: "missing_endpoint" },
+      { status: 503 }
+    );
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ML_WARMUP_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${ML_ENDPOINT}/v1/health`, {
+      method: "GET",
+      headers: {
+        "x-api-secret": API_SECRET,
+      },
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    if (response.ok) {
+      return NextResponse.json({ status: "ready" }, { status: 200 });
+    }
+
+    if ([408, 425, 429, 502, 503, 504].includes(response.status)) {
+      return NextResponse.json(
+        { status: "waking", reason: `upstream_${response.status}` },
+        { status: 202 }
+      );
+    }
+
+    return NextResponse.json(
+      { status: "error", reason: `upstream_${response.status}` },
+      { status: 503 }
+    );
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return NextResponse.json(
+        { status: "waking", reason: "timeout" },
+        { status: 202 }
+      );
+    }
+
+    return NextResponse.json(
+      { status: "error", reason: "request_failed" },
+      { status: 503 }
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/components/focus/focus-floating-widget.tsx
+++ b/components/focus/focus-floating-widget.tsx
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { useFocusSessionController } from '@/components/focus/focus-session-provider'
-import { formatTime } from '@/lib/focus-mode'
-import { PauseCircle, Square, X, Minimize2, Maximize2 } from 'lucide-react'
+import { formatTime, formatDuration } from '@/lib/focus-mode'
+import { PauseCircle, Square, X, Minimize2, Maximize2, ClipboardCheck } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
@@ -14,7 +14,14 @@ import type { InterruptionDetail } from '@/types/database'
 export function FocusFloatingWidget() {
   const pathname = usePathname()
   const router = useRouter()
-  const { activeSession, remainingSeconds, elapsedSeconds, endSession, isEnding } = useFocusSessionController()
+  const {
+    activeSession,
+    pendingCompletionSession,
+    remainingSeconds,
+    elapsedSeconds,
+    endSession,
+    isEnding,
+  } = useFocusSessionController()
   const [isDismissed, setIsDismissed] = useState(false)
   const [isMinimized, setIsMinimized] = useState(false)
   const [isExpanding, setIsExpanding] = useState(false)
@@ -32,6 +39,13 @@ export function FocusFloatingWidget() {
       setConfirmEnd(false)
     }
   }, [activeSession])
+
+  // Reset dismissed state when a pending completion appears
+  useEffect(() => {
+    if (pendingCompletionSession) {
+      setIsDismissed(false)
+    }
+  }, [pendingCompletionSession])
 
   const handleExpand = useCallback(() => {
     setIsExpanding(true)
@@ -65,7 +79,69 @@ export function FocusFloatingWidget() {
     }
   }, [activeSession, elapsedSeconds, endSession])
 
+  // Don't show widget on the focus page itself
   if (pathname === '/dashboard/focus') return null
+
+  // Show pending completion widget when user hasn't filled reflection
+  if (!activeSession && pendingCompletionSession && !isDismissed) {
+    const pendingTaskLabel =
+      pendingCompletionSession.session.custom_task_text ||
+      pendingCompletionSession.session.tasks?.title ||
+      'Focus Session'
+
+    return (
+      <>
+        <div ref={constraintsRef} className="fixed inset-4 pointer-events-none z-[-1]" />
+        <motion.div
+          ref={widgetRef}
+          drag
+          dragMomentum={false}
+          dragElastic={0.05}
+          dragConstraints={constraintsRef}
+          className="fixed bottom-4 right-4 z-[100] flex cursor-grab flex-col active:cursor-grabbing select-none touch-none"
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.95 }}
+        >
+          <div className="overflow-hidden rounded-[24px] border border-amber-500/30 bg-background/70 shadow-[0_8px_32px_0_rgba(0,0,0,0.12)] backdrop-blur-3xl w-[min(360px,calc(100vw-2rem))]">
+            <div className="p-5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <ClipboardCheck className="h-4 w-4 text-amber-500" />
+                    <p className="text-xs font-bold uppercase tracking-[0.2em] text-amber-500">
+                      Reflection needed
+                    </p>
+                  </div>
+                  <p className="mt-2 truncate text-sm text-muted-foreground">{pendingTaskLabel}</p>
+                  <p className="mt-1 text-sm font-medium text-foreground">
+                    {formatDuration(pendingCompletionSession.actualDuration)} focused
+                  </p>
+                </div>
+              </div>
+
+              <p className="mt-3 text-xs text-muted-foreground">
+                Your session ended — please fill in your reflection to save it.
+              </p>
+
+              <div className="mt-4">
+                <Button
+                  variant="default"
+                  size="sm"
+                  className="h-10 w-full rounded-full px-4 font-medium"
+                  onClick={handleExpand}
+                >
+                  <ClipboardCheck className="mr-2 h-4 w-4" />
+                  Complete Reflection
+                </Button>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      </>
+    )
+  }
+
   if (isDismissed) return null
   if (!activeSession) return null
 
@@ -204,3 +280,4 @@ export function FocusFloatingWidget() {
     </>
   )
 }
+

--- a/components/focus/focus-hub-client.tsx
+++ b/components/focus/focus-hub-client.tsx
@@ -17,6 +17,7 @@ export function FocusHubClient() {
   const {
     activeSession,
     endedSession,
+    pendingCompletionSession,
     isLoading: isLoadingActiveSession,
     clearEndedSession,
   } = useFocusSessionController()
@@ -52,12 +53,15 @@ export function FocusHubClient() {
     return <ActiveTimer session={activeSession} />
   }
 
-  if (endedSession) {
+  // Show completion screen for both in-memory ended sessions and
+  // sessions that were pending completion from previous page loads
+  const completionData = endedSession || pendingCompletionSession
+  if (completionData) {
     return (
       <SessionCompletion
-        session={endedSession.session}
-        actualDuration={endedSession.actualDuration}
-        interruptions={endedSession.interruptions}
+        session={completionData.session}
+        actualDuration={completionData.actualDuration}
+        interruptions={completionData.interruptions}
         onComplete={handleCompletionDone}
       />
     )

--- a/components/focus/focus-session-provider.tsx
+++ b/components/focus/focus-session-provider.tsx
@@ -13,8 +13,8 @@ import { useQueryClient } from '@tanstack/react-query'
 import { createClient } from '@/lib/supabase/client'
 import {
   createFocusSession,
-  endFocusSessionRecord,
   fetchActiveFocusSession,
+  finalizeSessionReflection,
   updateFocusSessionRecord,
 } from '@/lib/focus/focus-session-client'
 import { playFocusSound } from '@/lib/focus/audio'
@@ -55,6 +55,7 @@ interface FocusSessionContextValue {
   remainingSeconds: number
   elapsedSeconds: number
   endedSession: EndedSessionState | null
+  pendingCompletionSession: EndedSessionState | null
   startSession: (input: StartFocusSessionInput) => Promise<FocusSession>
   endSession: (options?: EndSessionOptions) => Promise<FocusSession | null>
   syncActiveSession: () => Promise<FocusSession | null>
@@ -63,6 +64,16 @@ interface FocusSessionContextValue {
     sessionId: number,
     updates: {
       moodAfter?: number | null
+      energyEnd?: number | null
+      interruptions?: number
+      interruptionDetails?: InterruptionDetail[]
+      metadata?: Record<string, unknown>
+    }
+  ) => Promise<FocusSession>
+  finalizeReflection: (
+    sessionId: number,
+    updates: {
+      moodAfter: number
       energyEnd?: number | null
       interruptions?: number
       interruptionDetails?: InterruptionDetail[]
@@ -83,9 +94,27 @@ function getElapsedSeconds(session: FocusSession) {
   return Math.max(0, elapsed)
 }
 
-function getRemainingSeconds(session: FocusSession) {
-  const remaining = Math.floor((getSessionEndTimestamp(session) - Date.now()) / 1000)
-  return Math.max(0, remaining)
+function getSessionInterruptions(session: FocusSession) {
+  return ((session.interruption_details as InterruptionDetail[] | null) ?? [])
+}
+
+function buildEndedSessionState(
+  session: FocusSession,
+  interruptions: InterruptionDetail[],
+  source: EndReason,
+  actualDuration = session.actual_duration ?? session.planned_duration
+): EndedSessionState {
+  return {
+    session: {
+      ...session,
+      actual_duration: actualDuration,
+      interruption_details: interruptions,
+    },
+    actualDuration,
+    interruptions,
+    completed: actualDuration >= session.planned_duration,
+    source,
+  }
 }
 
 export function FocusSessionProvider({ children }: { children: React.ReactNode }) {
@@ -96,14 +125,83 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
   const [isEnding, setIsEnding] = useState(false)
   const [now, setNow] = useState(() => Date.now())
   const [endedSession, setEndedSession] = useState<EndedSessionState | null>(null)
+  const [pendingCompletionSession, setPendingCompletionSession] = useState<EndedSessionState | null>(null)
 
   const supabaseRef = useRef(createClient())
   const autoEndingSessionIdRef = useRef<number | null>(null)
+  const lastCompletionSoundSessionIdRef = useRef<number | null>(null)
   const syncPromiseRef = useRef<Promise<FocusSession | null> | null>(null)
 
   const invalidateFocusQueries = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ['focus-sessions'] })
   }, [queryClient])
+
+  const resolveSessionState = useCallback(async (session: FocusSession | null) => {
+    if (!session) {
+      setActiveSession(null)
+      setPendingCompletionSession(null)
+      return null
+    }
+
+    const endMs = getSessionEndTimestamp(session)
+    if (Date.now() < endMs) {
+      setPendingCompletionSession(null)
+      setActiveSession(session)
+      return session
+    }
+
+    const existingInterruptions = getSessionInterruptions(session)
+    const alreadyHasLeftAppInterruption = existingInterruptions.some(
+      (detail) => detail.type === 'other' && detail.label === 'User left the app'
+    )
+
+    let resolvedSession = session
+    let finalInterruptions = existingInterruptions
+    const endedAt = session.ended_at ?? new Date(endMs).toISOString()
+
+    if (!alreadyHasLeftAppInterruption) {
+      finalInterruptions = [
+        ...existingInterruptions,
+        {
+          type: 'other',
+          label: 'User left the app',
+          timestamp: new Date(endMs).toISOString(),
+        },
+      ]
+
+      try {
+        resolvedSession = await updateFocusSessionRecord(session.session_id, {
+          interruptionDetails: finalInterruptions,
+          interruptions: finalInterruptions.length,
+          actualDuration: session.planned_duration,
+          endedAt,
+        })
+      } catch (updateError) {
+        console.error('Failed to persist away interruption:', updateError)
+      }
+    }
+
+    setActiveSession(null)
+    setPendingCompletionSession(
+      buildEndedSessionState(
+        {
+          ...resolvedSession,
+          ended_at: endedAt,
+          actual_duration: resolvedSession.actual_duration ?? session.planned_duration,
+          interruption_details: finalInterruptions,
+        },
+        finalInterruptions,
+        'completed',
+        resolvedSession.actual_duration ?? session.planned_duration
+      )
+    )
+    if (lastCompletionSoundSessionIdRef.current !== session.session_id) {
+      lastCompletionSoundSessionIdRef.current = session.session_id
+      playFocusSound()
+    }
+
+    return null
+  }, [])
 
   const syncActiveSession = useCallback(async () => {
     if (syncPromiseRef.current) {
@@ -113,12 +211,11 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
     const promise = (async () => {
       try {
         const session = await fetchActiveFocusSession()
-        setActiveSession(session)
+        const resolvedSession = await resolveSessionState(session)
         setNow(Date.now())
         invalidateFocusQueries()
-        return session
+        return resolvedSession
       } finally {
-        // Small micro-throttle to prevent rapid consecutive calls
         setTimeout(() => {
           syncPromiseRef.current = null
         }, 1000)
@@ -127,7 +224,7 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
 
     syncPromiseRef.current = promise
     return promise
-  }, [invalidateFocusQueries])
+  }, [invalidateFocusQueries, resolveSessionState])
 
   useEffect(() => {
     let isMounted = true
@@ -135,9 +232,9 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
     async function initialSync() {
       try {
         const session = await fetchActiveFocusSession()
-        if (isMounted) {
-          setActiveSession(session)
-        }
+        if (!isMounted) return
+
+        await resolveSessionState(session)
       } catch (error) {
         console.error('Failed to sync active focus session:', error)
       } finally {
@@ -152,7 +249,7 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
     return () => {
       isMounted = false
     }
-  }, [])
+  }, [resolveSessionState])
 
   useEffect(() => {
     if (!activeSession) return
@@ -253,14 +350,16 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
       try {
         const current = await fetchActiveFocusSession()
         if (current) {
-          setActiveSession(current)
-          return current
+          const resolvedCurrent = await resolveSessionState(current)
+          return resolvedCurrent ?? current
         }
 
         const session = await createFocusSession(input)
         setActiveSession(session)
         setNow(Date.now())
         setEndedSession(null)
+        setPendingCompletionSession(null)
+        lastCompletionSoundSessionIdRef.current = null
         invalidateFocusQueries()
         playFocusSound()
         return session
@@ -268,7 +367,7 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
         setIsStarting(false)
       }
     },
-    [invalidateFocusQueries]
+    [invalidateFocusQueries, resolveSessionState]
   )
 
   const endSession = useCallback(
@@ -279,8 +378,7 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
 
       try {
         const interruptionDetails =
-          options.interruptionDetails ??
-          ((activeSession.interruption_details as InterruptionDetail[] | null) ?? [])
+          options.interruptionDetails ?? getSessionInterruptions(activeSession)
 
         const actualDuration =
           options.actualDuration ?? Math.min(activeSession.planned_duration, getElapsedSeconds(activeSession))
@@ -296,11 +394,8 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
           endedReason: options.reason ?? 'manual',
         }
 
-        const session = await endFocusSessionRecord({
-          sessionId: activeSession.session_id,
+        const session = await updateFocusSessionRecord(activeSession.session_id, {
           actualDuration,
-          moodAfter: options.moodAfter ?? 3,
-          energyEnd: options.energyEnd ?? activeSession.energy_start ?? null,
           interruptions: options.interruptions ?? interruptionDetails.length,
           interruptionDetails,
           endedAt,
@@ -310,19 +405,10 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
         setActiveSession(null)
         setNow(Date.now())
         invalidateFocusQueries()
-
-        if (options.showCompletion) {
-          setEndedSession({
-            session,
-            actualDuration,
-            interruptions: interruptionDetails,
-            completed: actualDuration >= activeSession.planned_duration,
-            source: options.reason ?? 'manual',
-          })
-          playFocusSound()
-        } else if ((options.reason ?? 'manual') === 'remote') {
-          setEndedSession(null)
-        }
+        setPendingCompletionSession(
+          buildEndedSessionState(session, interruptionDetails, options.reason ?? 'manual', actualDuration)
+        )
+        playFocusSound()
 
         return session
       } finally {
@@ -337,7 +423,7 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
       if (!activeSession) return
 
       const interruptionDetails = [
-        ...(((activeSession.interruption_details as InterruptionDetail[] | null) ?? [])),
+        ...getSessionInterruptions(activeSession),
         detail,
       ]
 
@@ -385,6 +471,28 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
     [invalidateFocusQueries]
   )
 
+  const finalizeReflection = useCallback(
+    async (
+      sessionId: number,
+      updates: {
+        moodAfter: number
+        energyEnd?: number | null
+        interruptions?: number
+        interruptionDetails?: InterruptionDetail[]
+        metadata?: Record<string, unknown>
+      }
+    ) => {
+      const session = await finalizeSessionReflection(sessionId, updates)
+
+      invalidateFocusQueries()
+      setEndedSession(null)
+      setPendingCompletionSession(null)
+      lastCompletionSoundSessionIdRef.current = null
+      return session
+    },
+    [invalidateFocusQueries]
+  )
+
   useEffect(() => {
     if (!activeSession) {
       autoEndingSessionIdRef.current = null
@@ -403,18 +511,38 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
 
     autoEndingSessionIdRef.current = activeSession.session_id
 
-    void endSession({
-      actualDuration: activeSession.planned_duration,
-      reason: 'completed',
-      showCompletion: true,
-      metadata: {
-        autoCompleted: true,
-      },
-    }).catch((error) => {
-      autoEndingSessionIdRef.current = null
-      console.error('Failed to auto-complete focus session:', error)
-    })
-  }, [activeSession, endSession, now])
+    const endMs = getSessionEndTimestamp(activeSession)
+    const existingInterruptions = getSessionInterruptions(activeSession)
+
+    void (async () => {
+      try {
+        await updateFocusSessionRecord(activeSession.session_id, {
+          actualDuration: activeSession.planned_duration,
+          endedAt: new Date(endMs).toISOString(),
+        })
+
+        setActiveSession(null)
+        setPendingCompletionSession(
+          buildEndedSessionState(
+            {
+              ...activeSession,
+              actual_duration: activeSession.planned_duration,
+              ended_at: new Date(endMs).toISOString(),
+            },
+            existingInterruptions,
+            'completed',
+            activeSession.planned_duration
+          )
+        )
+        lastCompletionSoundSessionIdRef.current = activeSession.session_id
+        invalidateFocusQueries()
+        playFocusSound()
+      } catch (error) {
+        autoEndingSessionIdRef.current = null
+        console.error('Failed to auto-complete focus session:', error)
+      }
+    })()
+  }, [activeSession, invalidateFocusQueries, now])
 
   const remainingSeconds = useMemo(() => {
     if (!activeSession) return 0
@@ -435,12 +563,17 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
       remainingSeconds,
       elapsedSeconds,
       endedSession,
+      pendingCompletionSession,
       startSession,
       endSession,
       syncActiveSession,
       addInterruption,
       saveSessionReflection,
-      clearEndedSession: () => setEndedSession(null),
+      finalizeReflection,
+      clearEndedSession: () => {
+        setEndedSession(null)
+        setPendingCompletionSession(null)
+      },
     }),
     [
       activeSession,
@@ -448,9 +581,11 @@ export function FocusSessionProvider({ children }: { children: React.ReactNode }
       elapsedSeconds,
       endSession,
       endedSession,
+      finalizeReflection,
       isEnding,
       isLoading,
       isStarting,
+      pendingCompletionSession,
       remainingSeconds,
       saveSessionReflection,
       startSession,

--- a/components/focus/session-completion.tsx
+++ b/components/focus/session-completion.tsx
@@ -25,7 +25,7 @@ export function SessionCompletion({
   interruptions,
   onComplete,
 }: SessionCompletionProps) {
-  const { saveSessionReflection } = useFocusSessionController()
+  const { finalizeReflection } = useFocusSessionController()
   const [moodAfter, setMoodAfter] = useState<number | null>(session.mood_after ?? null)
   const [energyEnd, setEnergyEnd] = useState<number | null>(session.energy_end ?? session.energy_start)
   const [reflection, setReflection] = useState('')
@@ -44,7 +44,7 @@ export function SessionCompletion({
     try {
       const existingMetadata = (session.metadata as Record<string, unknown>) ?? {}
 
-      await saveSessionReflection(session.session_id, {
+      await finalizeReflection(session.session_id, {
         moodAfter,
         energyEnd,
         interruptions: interruptions.length,
@@ -71,7 +71,7 @@ export function SessionCompletion({
     moodAfter,
     onComplete,
     reflection,
-    saveSessionReflection,
+    finalizeReflection,
     session.metadata,
     session.session_id,
   ])

--- a/components/service-status-indicator.tsx
+++ b/components/service-status-indicator.tsx
@@ -17,7 +17,6 @@ import {
 export function ServiceStatusIndicator() {
   const { status, isReady, retry } = useWarmServices();
 
-  // Don't show anything if ready - completely invisible success
   if (isReady) {
     return null;
   }
@@ -38,7 +37,7 @@ export function ServiceStatusIndicator() {
           <button
             onClick={status === "error" ? retry : undefined}
             className={cn(
-              "w-2 h-2 rounded-full transition-all duration-300",
+              "w-2.5 h-2.5 rounded-full transition-all duration-300",
               config.color,
               status === "error" && "cursor-pointer hover:opacity-100"
             )}

--- a/hooks/use-warm-services.ts
+++ b/hooks/use-warm-services.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 type ServiceStatus = "idle" | "waking" | "ready" | "error";
 
@@ -10,30 +10,63 @@ interface UseWarmServicesResult {
   retry: () => void;
 }
 
-import { warmServicesAction } from "@/app/actions/ml";
 /**
  * Hook that pings the ML services to wake them from Render's cold start.
  * Runs automatically on mount, with subtle status tracking.
  */
 export function useWarmServices(): UseWarmServicesResult {
   const [status, setStatus] = useState<ServiceStatus>("idle");
+  const abortRef = useRef<AbortController | null>(null);
+  const retryTimerRef = useRef<number | null>(null);
 
   const warmUp = useCallback(async () => {
+    abortRef.current?.abort();
+    if (retryTimerRef.current !== null) {
+      window.clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+
     setStatus("waking");
 
     try {
-      const isOk = await warmServicesAction();
+      const controller = new AbortController();
+      abortRef.current = controller;
 
-      if (isOk) {
+      const response = await fetch("/api/ai/health", {
+        method: "GET",
+        cache: "no-store",
+        signal: controller.signal,
+      });
+
+      const payload = (await response.json().catch(() => null)) as { status?: ServiceStatus } | null;
+      const nextStatus = payload?.status;
+
+      if (nextStatus === "ready") {
         setStatus("ready");
-        console.log("[WarmServices] ML services are ready");
-      } else {
-        setStatus("error");
-        console.warn("[WarmServices] Health check failed");
+        return;
       }
-    } catch (error) {
+
+      if (nextStatus === "waking") {
+        setStatus("waking");
+        retryTimerRef.current = window.setTimeout(() => {
+          retryTimerRef.current = null;
+          void warmUp();
+        }, 5000);
+        return;
+      }
+
+      if (!response.ok) {
+        setStatus("error");
+        return;
+      }
+
       setStatus("error");
-      console.warn("[WarmServices] Failed to reach ML services:", error);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+
+      setStatus("error");
     }
   }, []);
 
@@ -58,6 +91,10 @@ export function useWarmServices(): UseWarmServicesResult {
     const timeoutId = globalThis.setTimeout(runWarmUp, 1200);
     return () => {
       cancelled = true;
+      abortRef.current?.abort();
+      if (retryTimerRef.current !== null) {
+        window.clearTimeout(retryTimerRef.current);
+      }
       globalThis.clearTimeout(timeoutId);
     };
   }, [warmUp]);

--- a/lib/focus/audio.ts
+++ b/lib/focus/audio.ts
@@ -1,12 +1,22 @@
 export function playFocusSound() {
   if (typeof window === 'undefined') return
   if (window.localStorage.getItem('rhythme-focus-sound') === 'false') return
-  
+
   try {
     const audio = new Audio('/sounds/bell.mp3')
     audio.volume = 0.6
-    void audio.play()
-  } catch (err) {
-    console.error('Failed to play focus sound', err)
+
+    const playPromise = audio.play()
+    if (playPromise && typeof playPromise.catch === 'function') {
+      void playPromise.catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === 'NotAllowedError') {
+          return
+        }
+
+        console.error('Failed to play focus sound', error)
+      })
+    }
+  } catch (error) {
+    console.error('Failed to play focus sound', error)
   }
 }

--- a/lib/focus/focus-session-client.ts
+++ b/lib/focus/focus-session-client.ts
@@ -284,3 +284,79 @@ export async function updateFocusSessionRecord(
 
   return mapSession(data as FocusSessionRow)
 }
+
+/**
+ * Fetch a session that is "pending completion" — is_active is still true but the
+ * planned duration has already elapsed (timer expired while user was away or
+ * the user hasn't submitted their reflection yet).
+ */
+export async function fetchPendingCompletionSession(): Promise<FocusSession | null> {
+  const { supabase, userId } = await getAuthenticatedUserId()
+
+  const { data, error } = await supabase
+    .from('focus_sessions')
+    .select(FOCUS_SESSION_SELECT)
+    .eq('user_id', userId)
+    .eq('is_active', true)
+    .order('started_at', { ascending: false })
+    .limit(1)
+
+  if (error) {
+    throw error
+  }
+
+  const row = data?.[0] as FocusSessionRow | undefined
+  if (!row) return null
+
+  const session = mapSession(row)
+  const startedMs = new Date(session.started_at).getTime()
+  const endMs = startedMs + session.planned_duration * 1000
+
+  // Session time has elapsed — it needs reflection
+  if (Date.now() >= endMs) {
+    return session
+  }
+
+  return null
+}
+
+/**
+ * Finalize a session after the user fills in their reflection.
+ * This is the ONLY place where is_active is set to false for completed sessions.
+ */
+export async function finalizeSessionReflection(
+  sessionId: number,
+  updates: {
+    moodAfter: number
+    energyEnd?: number | null
+    interruptions?: number
+    interruptionDetails?: InterruptionDetail[]
+    metadata?: Record<string, unknown>
+  }
+): Promise<FocusSession> {
+  const { supabase, userId } = await getAuthenticatedUserId()
+
+  const payload: Record<string, unknown> = {
+    is_active: false,
+    mood_after: updates.moodAfter,
+  }
+
+  if (updates.energyEnd !== undefined) payload.energy_end = updates.energyEnd
+  if (updates.interruptions !== undefined) payload.interruptions = updates.interruptions
+  if (updates.interruptionDetails !== undefined) payload.interruption_details = updates.interruptionDetails
+  if (updates.metadata !== undefined) payload.metadata = updates.metadata
+
+  const { data, error } = await supabase
+    .from('focus_sessions')
+    .update(payload)
+    .eq('session_id', sessionId)
+    .eq('user_id', userId)
+    .select(FOCUS_SESSION_SELECT)
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  return mapSession(data as FocusSessionRow)
+}

--- a/store/useFocusStore.ts
+++ b/store/useFocusStore.ts
@@ -2,7 +2,6 @@
 // Zustand store with persist middleware for Focus Timer state
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
-import { toast } from 'sonner'
 
 export type SessionType = 'focus' | 'break'
 
@@ -142,19 +141,13 @@ export const useFocusStore = create<FocusTimerState>()(
           const remaining = Math.max(0, state.targetDuration - elapsed)
           
           if (remaining <= 0) {
-            // Timer completed while away — notify the user
+            // Timer completed while away — stop the local timer.
+            // The FocusSessionProvider will detect the expired session
+            // in the DB (is_active=true but time elapsed), add an
+            // interruption, and show the persistent completion screen.
             state.isRunning = false
             state.timeLeft = 0
             state.startedAt = null
-
-            // Play bell and show toast on next tick (after React mounts)
-            setTimeout(() => {
-              try {
-                const audio = new Audio('/sounds/bell.mp3')
-                audio.play().catch(() => {})
-              } catch {}
-              toast.info('A focus session completed while you were away!')
-            }, 500)
           } else {
             state.timeLeft = remaining
           }


### PR DESCRIPTION
Introduce a /api/ai/health route to probe the ML service readiness and replace the old warmServicesAction with a client-side useWarmServices hook that polls this endpoint with retry/abort logic (uses ML_WARMUP_TIMEOUT_MS and ML_WARMUP behavior). Update ServiceStatusIndicator styling.

Implement persistent "pending completion" for focus sessions that expire while the user is away: add fetchPendingCompletionSession and finalizeSessionReflection in focus-session-client, and refactor FocusSessionProvider to detect elapsed active sessions, persist an away interruption, expose pendingCompletionSession, and provide finalizeReflection. Update session lifecycle to set pendingCompletionSession and play a completion sound once, auto-complete sessions by updating the DB, and clear state on finalization. Propagate changes to UI: FocusFloatingWidget displays a reflection-needed widget for pending completions, FocusHubClient shows completion data from pending sessions, and SessionCompletion submits via finalizeReflection. Also improve audio playback error handling and stop showing a local toast in useFocusStore when a timer completes while away.