### PR TITLE
Improve insights fetching, normalization and UI

### DIFF
--- a/app/actions/ml.ts
+++ b/app/actions/ml.ts
@@ -30,7 +30,7 @@ export async function fetchPredictionAction(
 }
 
 export interface InsightResult {
-  insights: Array<{
+  insights: Array<string | {
     sentence?: string
     insight?: string
     headline?: string
@@ -44,6 +44,8 @@ export interface InsightResult {
     score?: number
     strength_score?: number
   }>
+  days_analyzed?: number
+  message?: string | null
 }
 
 export async function fetchInsightsAction(params: {
@@ -64,8 +66,14 @@ export async function fetchInsightsAction(params: {
     throw new Error("Not authenticated")
   }
 
-  const fromIso = new Date(`${params.from}T00:00:00`).toISOString()
-  const toIso = new Date(`${params.to}T23:59:59`).toISOString()
+  const toDate = new Date()
+  const fromDate = new Date()
+  fromDate.setDate(toDate.getDate() - 90)
+  fromDate.setHours(0, 0, 0, 0)
+  toDate.setHours(23, 59, 59, 999)
+
+  const fromIso = fromDate.toISOString()
+  const toIso = toDate.toISOString()
 
   const [tasksResult, habitLogsResult, journalsResult, moodResult, focusResult] =
     await Promise.all([
@@ -105,33 +113,42 @@ export async function fetchInsightsAction(params: {
   // Build daily log entries grouped by date
   const dayMap = new Map<string, {
     date: string
-    tasks_completed: number
+    tasks_done: number
     tasks_created: number
     habits_completed: number
-    journal_count: number
-    mood_score: number | null
-    focus_minutes: number
+    journaled: boolean
+    mood: number
+    focus_mins: number
     focus_sessions: number
   }>()
+
+  // Pre-fill every date in the range
+  for (let d = new Date(fromDate); d <= toDate; d.setDate(d.getDate() + 1)) {
+    const key = d.toISOString().slice(0, 10)
+    dayMap.set(key, {
+      date: key, tasks_done: 0, tasks_created: 0, habits_completed: 0,
+      journaled: false, mood: 6, focus_mins: 0, focus_sessions: 0,
+    })
+  }
 
   const getDateKey = (value: string) => value.slice(0, 10)
 
   for (const task of tasksResult.data ?? []) {
     const key = getDateKey(task.created_at)
     const entry = dayMap.get(key) ?? {
-      date: key, tasks_completed: 0, tasks_created: 0, habits_completed: 0,
-      journal_count: 0, mood_score: null, focus_minutes: 0, focus_sessions: 0,
+      date: key, tasks_done: 0, tasks_created: 0, habits_completed: 0,
+      journaled: false, mood: 6, focus_mins: 0, focus_sessions: 0,
     }
     entry.tasks_created += 1
-    if (task.status === "completed" || task.completed_at) entry.tasks_completed += 1
+    if (task.status === "completed" || task.completed_at) entry.tasks_done += 1
     dayMap.set(key, entry)
   }
 
   for (const log of habitLogsResult.data ?? []) {
     const key = getDateKey(log.completed_at)
     const entry = dayMap.get(key) ?? {
-      date: key, tasks_completed: 0, tasks_created: 0, habits_completed: 0,
-      journal_count: 0, mood_score: null, focus_minutes: 0, focus_sessions: 0,
+      date: key, tasks_done: 0, tasks_created: 0, habits_completed: 0,
+      journaled: false, mood: 6, focus_mins: 0, focus_sessions: 0,
     }
     entry.habits_completed += 1
     dayMap.set(key, entry)
@@ -140,42 +157,51 @@ export async function fetchInsightsAction(params: {
   for (const journal of journalsResult.data ?? []) {
     const key = getDateKey(journal.created_at)
     const entry = dayMap.get(key) ?? {
-      date: key, tasks_completed: 0, tasks_created: 0, habits_completed: 0,
-      journal_count: 0, mood_score: null, focus_minutes: 0, focus_sessions: 0,
+      date: key, tasks_done: 0, tasks_created: 0, habits_completed: 0,
+      journaled: false, mood: 6, focus_mins: 0, focus_sessions: 0,
     }
-    entry.journal_count += 1
+    entry.journaled = true
     dayMap.set(key, entry)
   }
 
   for (const mood of moodResult.data ?? []) {
     const key = mood.logged_at
     const entry = dayMap.get(key) ?? {
-      date: key, tasks_completed: 0, tasks_created: 0, habits_completed: 0,
-      journal_count: 0, mood_score: null, focus_minutes: 0, focus_sessions: 0,
+      date: key, tasks_done: 0, tasks_created: 0, habits_completed: 0,
+      journaled: false, mood: 6, focus_mins: 0, focus_sessions: 0,
     }
-    entry.mood_score = Number(mood.mood_score)
+    entry.mood = Math.round(Number(mood.mood_score) * 2)
     dayMap.set(key, entry)
   }
 
   for (const session of focusResult.data ?? []) {
     const key = getDateKey(session.started_at)
     const entry = dayMap.get(key) ?? {
-      date: key, tasks_completed: 0, tasks_created: 0, habits_completed: 0,
-      journal_count: 0, mood_score: null, focus_minutes: 0, focus_sessions: 0,
+      date: key, tasks_done: 0, tasks_created: 0, habits_completed: 0,
+      journaled: false, mood: 6, focus_mins: 0, focus_sessions: 0,
     }
-    entry.focus_minutes += session.actual_duration ?? session.planned_duration
+    entry.focus_mins += session.actual_duration ?? session.planned_duration
     entry.focus_sessions += 1
     dayMap.set(key, entry)
   }
 
   const logs = Array.from(dayMap.values()).sort((a, b) => a.date.localeCompare(b.date))
 
-  if (logs.length < 7) {
-    return { insights: [] }
+  const totalDays = logs.length;
+  const daysWithActivity = logs.filter(l => 
+    l.tasks_done > 0 || l.habits_completed > 0 || l.journaled || l.focus_mins > 0 || l.mood !== 6
+  ).length;
+
+  if (daysWithActivity < 14) {
+    return { 
+      insights: [], 
+      days_analyzed: totalDays,
+      message: `Need at least 14 days of activity to generate insights. You currently have ${daysWithActivity} days with activity.` 
+    };
   }
 
   try {
-    const response = await fetch(`${ML_ENDPOINT}/v1/insight_weekly`, {
+    const response = await fetch(`${ML_ENDPOINT}/v1/insights_weekly`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -185,14 +211,15 @@ export async function fetchInsightsAction(params: {
     })
 
     if (!response.ok) {
-      throw new Error(`Insights service returned ${response.status}`)
+      const errorText = await response.text().catch(() => "Could not read error text")
+      throw new Error(`Insights service returned ${response.status}: ${errorText}`)
     }
 
     const payload = await response.json()
     return payload as InsightResult
-  } catch (error) {
+  } catch (error: any) {
     console.error("[Insights] Failed to fetch insights:", error)
-    throw new Error("The insights service is temporarily unavailable.")
+    throw new Error(`The insights service is temporarily unavailable. Details: ${error?.message || error}`)
   }
 }
 

--- a/components/activity/activity-page-client.tsx
+++ b/components/activity/activity-page-client.tsx
@@ -83,8 +83,8 @@ interface ActivityPageClientProps {
 interface NormalizedInsight {
   id: string
   sentence: string
-  strength: "Strong" | "Moderate"
-  explanation: string
+  strength?: "Strong" | "Moderate"
+  explanation?: string
 }
 
 const ACTIVITY_CALENDAR_CLASS_NAMES = {
@@ -709,12 +709,9 @@ function InsightsTab({
   const [error, setError] = useState<string | null>(null)
 
   const loadInsights = useCallback(async () => {
-    if (loggedDays < 14) {
-      setInsights([])
-      setError(null)
-      setIsLoading(false)
-      return
-    }
+    // We no longer short-circuit based on loggedDays here.
+    // The backend action (fetchInsightsAction) will check total days 
+    // and daysWithActivity, and return a helpful message if needed.
 
     setIsLoading(true)
     setError(null)
@@ -725,7 +722,12 @@ function InsightsTab({
         to: range.to,
       })
 
-      setInsights(normalizeInsights(result).slice(0, 5))
+      if (result.message && (!result.insights || result.insights.length === 0)) {
+        setError(result.message)
+        setInsights([])
+      } else {
+        setInsights(normalizeInsights(result))
+      }
     } catch (loadError) {
       setError(loadError instanceof Error ? loadError.message : "We couldn't refresh your insights.")
       setInsights([])
@@ -797,24 +799,33 @@ function InsightsTab({
       ) : (
         <div className="space-y-4">
           {insights.map((insight) => (
-            <Card key={insight.id} className="rounded-[28px] border-border/60 bg-card/70 shadow-sm">
-              <CardContent className="py-6">
-                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                  <div className="space-y-2">
-                    <p className="text-base font-medium leading-7">{insight.sentence}</p>
-                    <p className="text-sm leading-6 text-muted-foreground">{insight.explanation}</p>
+            <Card key={insight.id} className="group overflow-hidden rounded-[24px] border-border/40 bg-gradient-to-br from-card/80 to-card/40 shadow-sm transition-all hover:shadow-md hover:border-primary/20">
+              <CardContent className="p-5 sm:p-6">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start md:justify-between">
+                  <div className="flex gap-4 items-start flex-1">
+                    <div className="shrink-0 flex items-center justify-center w-10 h-10 rounded-2xl bg-primary/10 text-primary mt-0.5 group-hover:scale-110 group-hover:bg-primary/20 transition-all duration-300">
+                      <Sparkles className="w-5 h-5" />
+                    </div>
+                    <div className="space-y-1.5 pt-1">
+                      <p className="text-[15px] font-medium leading-relaxed text-foreground/90">{insight.sentence}</p>
+                      {insight.explanation && (
+                        <p className="text-sm leading-relaxed text-muted-foreground">{insight.explanation}</p>
+                      )}
+                    </div>
                   </div>
-                  <Badge
-                    variant="outline"
-                    className={cn(
-                      "shrink-0 rounded-full px-3 py-1",
-                      insight.strength === "Strong"
-                        ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-                        : "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300"
-                    )}
-                  >
-                    {insight.strength}
-                  </Badge>
+                  {insight.strength && (
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "shrink-0 rounded-full px-3 py-1 sm:mt-1",
+                        insight.strength === "Strong"
+                          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                          : "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300"
+                      )}
+                    >
+                      {insight.strength}
+                    </Badge>
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -998,7 +1009,16 @@ function normalizeInsights(payload: unknown): NormalizedInsight[] {
 }
 
 function normalizeInsightItem(item: unknown, index: number): NormalizedInsight | null {
-  if (!item || typeof item !== "object") return null
+  if (!item) return null
+
+  if (typeof item === "string") {
+    return {
+      id: `insight-${index}-${item.substring(0, 10)}`,
+      sentence: item,
+    }
+  }
+
+  if (typeof item !== "object") return null
 
   const record = item as Record<string, unknown>
   const sentence = getString(record.sentence) ?? getString(record.insight) ?? getString(record.headline) ?? getString(record.title)

--- a/components/weekly/weekly-page-client.tsx
+++ b/components/weekly/weekly-page-client.tsx
@@ -137,7 +137,8 @@ export function WeeklyPageClient({ activeHabits, isPremium }: WeeklyPageClientPr
     try {
       const res = await fetchInsightsAction({ from: weekStart, to: weekEnd })
       if (res.insights && res.insights.length > 0) {
-        setInsight(res.insights[0].sentence || res.insights[0].insight || "You are building strong habits.")
+        const first = res.insights[0]
+        setInsight(typeof first === 'string' ? first : (first.sentence || first.insight || "You are building strong habits."))
       } else {
         setInsight("No clear patterns surfaced for this week yet.")
       }

--- a/test-ml.js
+++ b/test-ml.js
@@ -1,0 +1,27 @@
+const ML_ENDPOINT = 'https://ml.api.amplecen.com';
+const API_SECRET = 'tDZmzDytasdasdafNJrsasdffdasdasdsfsdfsXRxJbigzWUENsdfsdfsdfCfsdfdsfeCGPRFVVdaSFgfwsgsgtmUrhuxfuVwktXFMtXmrEYLxneeQhnzWUEfjJvmRFZuDXRmekEgTruCPazVXXTPSuGEasdasdPAzRNvRWMijFxzsdasdasgfgsdDhHiWqqGffasfasfsdgfsdfgzvmGejYtsdgsgZmtqfKMUGpzxSMxJFPr';
+
+const logs = Array.from({length: 14}).map((_, i) => ({
+  date: `2026-05-${10+i}`,
+  tasks_done: i,
+  tasks_created: i+1,
+  habits_completed: i % 2,
+  journaled: i % 3 === 0,
+  mood: (i % 5) + 5,
+  focus_mins: i * 10,
+  focus_sessions: i % 3,
+}));
+
+fetch(`${ML_ENDPOINT}/v1/insights_weekly`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'x-api-secret': API_SECRET,
+  },
+  body: JSON.stringify({ logs }),
+})
+.then(async res => {
+  console.log('Status:', res.status);
+  console.log('Body:', await res.text());
+})
+.catch(console.error);


### PR DESCRIPTION
Expand and harden the insights flow: update the InsightResult shape, default to a 90-day range, pre-fill daily logs, rename/normalize daily fields (tasks_completed -> tasks_done, mood scaling, focus_mins, journaled), and require at least 14 days of activity before generating insights. Switch the ML endpoint to /v1/insights_weekly, include error body text on failures, and return days_analyzed/message when insufficient activity. Frontend changes: remove client-side short-circuit for loggedDays, surface backend message as an error, accept string insight items and optional strength/explanation, and refresh the insights card UI. Minor fix in weekly page to handle string-first insight. Add test-ml.js to exercise the new insights_weekly API.