### PR TITLE
Add Premium gating and UI for insights/weekly

### DIFF
--- a/components/activity/activity-page-client.tsx
+++ b/components/activity/activity-page-client.tsx
@@ -15,7 +15,11 @@ import {
   SlidersHorizontal,
   Sparkles,
   Timer,
+  Crown,
+  Lock,
 } from "lucide-react"
+import Link from "next/link"
+import { usePremium } from "@/hooks/use-premium"
 import { fetchInsightsAction } from "@/app/actions/ml"
 
 import {
@@ -117,6 +121,7 @@ export function ActivityPageClient({
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const isMobile = useIsMobile()
+  const { isPremium } = usePremium()
 
   const [typeFilter, setTypeFilter] = useState<ActivityType>("all")
   const [search, setSearch] = useState("")
@@ -268,8 +273,13 @@ export function ActivityPageClient({
             <TabsTrigger value="calendar" className="rounded-xl px-4">
               Calendar
             </TabsTrigger>
-            <TabsTrigger value="insights" className="rounded-xl px-4">
+            <TabsTrigger value="insights" className="rounded-xl px-4 flex items-center gap-1.5">
               Insights
+              {!isPremium && (
+                <Badge variant="secondary" className="px-1.5 py-0 text-[10px] uppercase tracking-wider text-primary border-primary/20 bg-primary/10">
+                  Premium
+                </Badge>
+              )}
             </TabsTrigger>
           </TabsList>
 
@@ -298,7 +308,7 @@ export function ActivityPageClient({
           </TabsContent>
 
           <TabsContent value="insights">
-            <InsightsTab loggedDays={summary.loggedDays} range={range} />
+            <InsightsTab loggedDays={summary.loggedDays} range={range} isPremium={isPremium} />
           </TabsContent>
         </Tabs>
       </div>
@@ -700,15 +710,24 @@ function CalendarTab({
 function InsightsTab({
   loggedDays,
   range,
+  isPremium,
 }: {
   loggedDays: number
   range: ActivityRange
+  isPremium: boolean
 }) {
   const [insights, setInsights] = useState<NormalizedInsight[]>([])
   const [isLoading, setIsLoading] = useState(loggedDays >= 14)
   const [error, setError] = useState<string | null>(null)
 
   const loadInsights = useCallback(async () => {
+    if (!isPremium) {
+      setInsights([])
+      setError(null)
+      setIsLoading(false)
+      return
+    }
+
     if (loggedDays < 14) {
       setInsights([])
       setError(null)
@@ -737,6 +756,33 @@ function InsightsTab({
   useEffect(() => {
     void loadInsights()
   }, [loadInsights])
+
+  if (!isPremium) {
+    return (
+      <Empty className="rounded-[28px] border-border/60 bg-card/60 py-16">
+        <EmptyHeader>
+          <EmptyMedia variant="icon" className="bg-primary/10 border-primary/20 text-primary mb-4">
+            <Sparkles className="h-6 w-6" />
+          </EmptyMedia>
+          <EmptyTitle>Unlock Behavioral Patterns</EmptyTitle>
+          <EmptyDescription className="max-w-md mx-auto mb-4">
+            Understand your personal productivity rhythm.
+            <ul className="mt-4 space-y-2 text-left">
+              <li className="flex items-center gap-2 text-foreground"><CheckCheck className="w-4 h-4 text-primary" /> Discover which habits improve your mood</li>
+              <li className="flex items-center gap-2 text-foreground"><CheckCheck className="w-4 h-4 text-primary" /> See when you focus best</li>
+              <li className="flex items-center gap-2 text-foreground"><CheckCheck className="w-4 h-4 text-primary" /> Know what affects your task completion</li>
+              <li className="flex items-center gap-2 text-foreground"><CheckCheck className="w-4 h-4 text-primary" /> Get actionable statistical insights</li>
+            </ul>
+          </EmptyDescription>
+          <Button asChild className="mt-4 rounded-xl bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20">
+            <Link href="/settings/subscription">
+              <Crown className="w-4 h-4 mr-2" /> Upgrade to Premium
+            </Link>
+          </Button>
+        </EmptyHeader>
+      </Empty>
+    )
+  }
 
   return (
     <div className="space-y-5">

--- a/components/premium-gate-modal.tsx
+++ b/components/premium-gate-modal.tsx
@@ -13,7 +13,7 @@ import { Crown, Sparkles, Lock, Zap } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { motion } from "framer-motion"
 
-export type PremiumGateReason = "journal" | "task" | "habit" | "mood"
+export type PremiumGateReason = "journal" | "task" | "habit" | "mood" | "weekly"
 
 const GATE_CONFIG: Record<PremiumGateReason, {
   title: string
@@ -45,6 +45,12 @@ const GATE_CONFIG: Record<PremiumGateReason, {
     limit: "1 mood log/day",
     icon: Lock,
   },
+  weekly: {
+    title: "Weekly Review Locked",
+    description: "Free users can plan their week. Reviews and AI insights require Premium.",
+    limit: "Planning only",
+    icon: Sparkles,
+  },
 }
 
 interface PremiumGateModalProps {
@@ -67,9 +73,9 @@ export function PremiumGateModal({ open, onOpenChange, reason }: PremiumGateModa
             initial={{ scale: 0.8, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ type: "spring", stiffness: 400, damping: 25 }}
-            className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-500/20 to-orange-500/20 border border-amber-500/30"
+            className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 border border-primary/20"
           >
-            <Icon className="h-8 w-8 text-amber-500" />
+            <Icon className="h-8 w-8 text-primary" />
           </motion.div>
 
           <DialogTitle className="text-center text-xl font-semibold">
@@ -91,11 +97,11 @@ export function PremiumGateModal({ open, onOpenChange, reason }: PremiumGateModa
               initial={{ width: 0 }}
               animate={{ width: "100%" }}
               transition={{ duration: 0.6, ease: "easeOut" }}
-              className="h-full rounded-full bg-gradient-to-r from-amber-500 to-orange-500"
+              className="h-full rounded-full bg-primary"
             />
           </div>
           <p className="mt-2 text-xs text-muted-foreground text-center">
-            You&apos;ve reached your limit for today
+            You've reached the free plan limit
           </p>
         </div>
 
@@ -107,7 +113,7 @@ export function PremiumGateModal({ open, onOpenChange, reason }: PremiumGateModa
           <div className="grid gap-1.5">
             {["Unlimited journals every day", "Unlimited tasks", "Unlimited mood logs", "Custom themes & more"].map((perk) => (
               <div key={perk} className="flex items-center gap-2 text-sm">
-                <Crown className="h-3.5 w-3.5 text-amber-500 shrink-0" />
+                <Crown className="h-3.5 w-3.5 text-primary shrink-0" />
                 <span className="text-muted-foreground">{perk}</span>
               </div>
             ))}
@@ -116,7 +122,7 @@ export function PremiumGateModal({ open, onOpenChange, reason }: PremiumGateModa
 
         <DialogFooter className="mt-4 flex flex-col gap-2 sm:flex-col">
           <Button
-            className="w-full gap-2 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white shadow-lg shadow-amber-500/25"
+            className="w-full gap-2 bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20"
             onClick={() => {
               onOpenChange(false)
               router.push("/settings/subscription")

--- a/components/weekly/weekly-page-client.tsx
+++ b/components/weekly/weekly-page-client.tsx
@@ -58,7 +58,7 @@ export function WeeklyPageClient({ activeHabits, isPremium }: WeeklyPageClientPr
 
   const [activeTab, setActiveTab] = useState<"plan" | "review">("plan")
   const [isGateOpen, setIsGateOpen] = useState(false)
-  const [gateReason, setGateReason] = useState<PremiumGateReason>("journal")
+  const [gateReason, setGateReason] = useState<PremiumGateReason>("weekly")
 
   // Data Hooks
   const { data: planData, isLoading: isLoadingPlan } = useWeeklyPlan(weekStart)
@@ -128,7 +128,7 @@ export function WeeklyPageClient({ activeHabits, isPremium }: WeeklyPageClientPr
   // Load Insight
   const loadInsight = async () => {
     if (!isPremium) {
-      setGateReason("journal")
+      setGateReason("weekly")
       setIsGateOpen(true)
       return
     }
@@ -164,7 +164,7 @@ export function WeeklyPageClient({ activeHabits, isPremium }: WeeklyPageClientPr
 
   const handleSaveReview = () => {
     if (!isPremium && reviewData === null) {
-      setGateReason("journal")
+      setGateReason("weekly")
       setIsGateOpen(true)
       return
     }


### PR DESCRIPTION
Introduce premium gating and UI affordances for Insights and Weekly flows. Use usePremium to show a "Premium" badge on the Insights tab and pass isPremium into InsightsTab; prevent loading insights for non-premium users and render an upsell empty state with benefits and an Upgrade CTA linking to /settings/subscription. Extend PremiumGateModal with a new "weekly" reason, update copy and visual styles to the primary palette, and tweak the perks/progress UI. Update weekly-page to default gateReason to "weekly" and open the premium gate for non-premium attempts to load insights or save a review.