### PR TITLE
Timezone-aware date handling and UI updates

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,12 +1,10 @@
 // app/(dashboard)/dashboard/page.tsx
 import { Suspense } from "react"
-import { Sun, CloudSun, Sunset, Moon } from "lucide-react"
 import { SiteHeader } from "@/components/site-header"
 import { Separator } from "@/components/ui/separator"
 import { getUser } from "../../actions/auth"
-import { getCalmTimeGreeting } from "@/lib/greetings/getCalmTimeGreeting"
-import { getGentleSubtitle } from "@/lib/greetings/getGentleSubtitle"
 import { getJournals } from "@/app/actions/journals"
+import { DashboardGreeting } from "@/components/dashboard/dashboard-greeting"
 
 // Dashboard components
 import {
@@ -33,16 +31,6 @@ export default async function DashboardPage() {
   const user = await getUser()
   const journals = await getJournals()
 
-  const hour = new Date().getHours()
-  let TimeIcon = Moon
-  if (hour >= 5 && hour < 12) {
-    TimeIcon = CloudSun
-  } else if (hour >= 12 && hour < 17) {
-    TimeIcon = Sun
-  } else if (hour >= 17 && hour < 22) {
-    TimeIcon = Sunset
-  }
-
   return (
     <>
       <SiteHeader />
@@ -50,29 +38,8 @@ export default async function DashboardPage() {
         <div className="@container/main flex flex-1 flex-col gap-4 md:gap-6 overflow-x-hidden">
           {/* Hero Section */}
           <div className="flex flex-col gap-4 py-4 md:py-6 px-3 sm:px-4 lg:px-6">
-            {/* Welcome Header */}
-            <header className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-              <div className="flex flex-col gap-1.5">
-                <h1 className="text-2xl md:text-3xl font-semibold font-primary tracking-tight text-foreground/90">
-                  {getCalmTimeGreeting(user?.name)}
-                </h1>
-                <p className="text-muted-foreground text-sm md:text-base">
-                  {getGentleSubtitle()}
-                </p>
-              </div>
-              <div className="flex items-center gap-2.5 px-4 py-2.5 bg-card/60 backdrop-blur-sm border border-border/50 rounded-2xl shadow-sm shrink-0">
-                <div className="p-1.5 bg-primary/10 rounded-full text-primary">
-                  <TimeIcon className="w-4 h-4" />
-                </div>
-                <div className="text-sm font-medium text-muted-foreground/80">
-                  {new Date().toLocaleDateString("en-US", {
-                    weekday: "long",
-                    month: "long",
-                    day: "numeric",
-                  })}
-                </div>
-              </div>
-            </header>
+            {/* Welcome Header — Client component for correct local timezone */}
+            <DashboardGreeting userName={user?.name} />
 
             <Separator className="my-2" />
 

--- a/app/(app)/journal/[journalId]/insights/insights-client.tsx
+++ b/app/(app)/journal/[journalId]/insights/insights-client.tsx
@@ -27,6 +27,7 @@ import { decryptJournal } from "@/lib/crypto";
 import { useJournalEncryptionStore } from "@/store/useJournalEncryptionStore";
 import { JournalUnlockModal } from "@/components/journal/journal-unlock-modal";
 import { analyzeJournalSentiment } from "@/app/actions/journals";
+import { toLocalDateTimeString } from "@/lib/timezone";
 
 // Mood labels
 const moodLabels: Record<MoodType, string> = {
@@ -683,7 +684,7 @@ export default function InsightsClient({
                     {analysis.analyzed_at && (
                       <>
                         {" · "}
-                        {new Date(analysis.analyzed_at).toLocaleString()}
+                        {toLocalDateTimeString(analysis.analyzed_at)}
                       </>
                     )}
                   </p>

--- a/app/(app)/settings/general/_components/general-section.tsx
+++ b/app/(app)/settings/general/_components/general-section.tsx
@@ -1,8 +1,9 @@
 // app/(dashboard)/settings/general/_components/general-section.tsx
-// General settings with flat design
+// General settings with timezone display
 
 "use client"
 
+import { useState, useEffect } from "react"
 import { Globe, Clock, Info } from "lucide-react"
 import { Label } from "@/components/ui/label"
 import {
@@ -13,8 +14,17 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { toast } from "sonner"
+import { getUserTimezone, getUTCOffsetString } from "@/lib/timezone"
 
 export function GeneralSection() {
+  const [timezone, setTimezone] = useState<string>("")
+  const [utcOffset, setUtcOffset] = useState<string>("")
+
+  useEffect(() => {
+    setTimezone(getUserTimezone())
+    setUtcOffset(getUTCOffsetString())
+  }, [])
+
   const handleComingSoon = () => {
     toast.info("This setting is coming soon!", {
       description: "We're working on making this configurable.",
@@ -59,22 +69,35 @@ export function GeneralSection() {
           <h3 className="font-medium">Timezone</h3>
         </div>
         
-        <div className="max-w-sm">
-          <Select defaultValue="auto" onValueChange={handleComingSoon}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select timezone" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="auto">Automatic (Browser)</SelectItem>
-              <SelectItem value="utc">UTC</SelectItem>
-              <SelectItem value="est">Eastern Time (ET)</SelectItem>
-              <SelectItem value="pst">Pacific Time (PT)</SelectItem>
-              <SelectItem value="ist">India Standard Time (IST)</SelectItem>
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground mt-2">
-            Used for scheduling reminders and displaying times.
-          </p>
+        <div className="max-w-sm space-y-3">
+          {/* Auto-detected timezone display */}
+          <div className="p-3 rounded-lg bg-muted/30 border border-border/50">
+            <p className="text-sm font-medium">
+              Current timezone:{" "}
+              <span className="text-primary">
+                {timezone || "Detecting..."}
+                {utcOffset && ` (${utcOffset})`}
+              </span>
+            </p>
+            <p className="text-xs text-muted-foreground mt-1.5">
+              Your daily reset happens at 00:00 in your local time.
+            </p>
+          </div>
+
+          {/* Manual override — coming soon */}
+          <div className="opacity-60 pointer-events-none">
+            <Select defaultValue="auto" disabled>
+              <SelectTrigger>
+                <SelectValue placeholder="Select timezone" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">Automatic (Browser)</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground mt-2">
+              Manual timezone override coming soon.
+            </p>
+          </div>
         </div>
       </section>
 
@@ -82,7 +105,7 @@ export function GeneralSection() {
       <div className="flex items-start gap-2 p-3 rounded-lg bg-muted/30 border border-border/50">
         <Info className="h-4 w-4 text-muted-foreground mt-0.5" />
         <p className="text-sm text-muted-foreground">
-          Additional preferences like date format and week start day will be added soon.
+          Your timezone is auto-detected from your browser. All daily logs, habits, and insights use your local time for accurate tracking.
         </p>
       </div>
     </div>

--- a/app/actions/habits.ts
+++ b/app/actions/habits.ts
@@ -89,7 +89,7 @@ const AT_RISK_THRESHOLD = 0.6;
 
 // === CRUD Operations ===
 
-export async function getHabits(): Promise<ActionResponse<HabitWithStats[]>> {
+export async function getHabits(localToday?: string): Promise<ActionResponse<HabitWithStats[]>> {
   try {
     const { supabase, user } = await getAuthenticatedUser();
 
@@ -120,7 +120,8 @@ export async function getHabits(): Promise<ActionResponse<HabitWithStats[]>> {
       return { error: logsError.message };
     }
 
-    const today = new Date().toISOString().split("T")[0];
+    // Use client-provided local date to avoid UTC day-boundary bugs
+    const today = localToday || new Date().toISOString().split("T")[0];
 
     // Map habits with their stats
     const habitsWithStats: HabitWithStats[] = habits.map((habit: Habit) => {
@@ -132,7 +133,7 @@ export async function getHabits(): Promise<ActionResponse<HabitWithStats[]>> {
       );
 
       // Period-based progress
-      const { start, end } = getPeriodBounds(freq);
+      const { start, end } = getPeriodBounds(freq, localToday);
       const periodLogs = habitLogs.filter(
         (log: HabitLog) => log.completed_at >= start && log.completed_at <= end,
       );
@@ -144,7 +145,7 @@ export async function getHabits(): Promise<ActionResponse<HabitWithStats[]>> {
         (log: HabitLog) => log.completed_at.split("T")[0] === today,
       );
       const completedThisWeek = (() => {
-        const weekBounds = getPeriodBounds(1);
+        const weekBounds = getPeriodBounds(1, localToday);
         return habitLogs.some(
           (log: HabitLog) =>
             log.completed_at >= weekBounds.start && log.completed_at <= weekBounds.end,
@@ -153,7 +154,7 @@ export async function getHabits(): Promise<ActionResponse<HabitWithStats[]>> {
 
       // Streak
       const completionDates = habitLogs.map((log: HabitLog) => log.completed_at);
-      const currentStreak = computeUnifiedStreak(freq, targetCount, completionDates);
+      const currentStreak = computeUnifiedStreak(freq, targetCount, completionDates, localToday);
 
       const daysOld = daysSince(new Date(habit.created_at));
       const canPredict = daysOld >= MIN_DAYS_FOR_PREDICTION;
@@ -186,6 +187,7 @@ export async function getHabits(): Promise<ActionResponse<HabitWithStats[]>> {
 
 export async function getHabit(
   habitId: number,
+  localToday?: string,
 ): Promise<ActionResponse<HabitWithStats>> {
   try {
     const { supabase, user } = await getAuthenticatedUser();
@@ -215,10 +217,10 @@ export async function getHabit(
 
     const freq = resolveFrequency(habit as unknown as Record<string, unknown>);
     const targetCount = habit.target_count ?? 1;
-    const today = new Date().toISOString().split("T")[0];
+    const today = localToday || new Date().toISOString().split("T")[0];
 
     // Period-based progress
-    const { start, end } = getPeriodBounds(freq);
+    const { start, end } = getPeriodBounds(freq, localToday);
     const periodLogs = (logs || []).filter(
       (log: HabitLog) => log.completed_at >= start && log.completed_at <= end,
     );
@@ -229,7 +231,7 @@ export async function getHabit(
     const completedToday = (logs || []).some(
       (log: HabitLog) => log.completed_at.split("T")[0] === today,
     );
-    const weekBounds = getPeriodBounds(1);
+    const weekBounds = getPeriodBounds(1, localToday);
     const completedThisWeek = (logs || []).some(
       (log: HabitLog) =>
         log.completed_at >= weekBounds.start && log.completed_at <= weekBounds.end,
@@ -237,7 +239,7 @@ export async function getHabit(
 
     // Streak
     const completionDates = (logs || []).map((log: HabitLog) => log.completed_at);
-    const currentStreak = computeUnifiedStreak(freq, targetCount, completionDates);
+    const currentStreak = computeUnifiedStreak(freq, targetCount, completionDates, localToday);
 
     const daysOld = daysSince(new Date(habit.created_at));
     const canPredict = daysOld >= MIN_DAYS_FOR_PREDICTION;
@@ -380,6 +382,7 @@ export async function deleteHabit(
 export async function logHabitCompletion(
   habitId: number,
   note?: string,
+  localToday?: string,
 ): Promise<ActionResponse<HabitLog>> {
   try {
     const { supabase, user } = await getAuthenticatedUser();
@@ -400,7 +403,7 @@ export async function logHabitCompletion(
     const targetCount = habit.target_count ?? 1;
 
     // Count-based validation: check if limit is reached for the current period
-    const { start, end } = getPeriodBounds(freq);
+    const { start, end } = getPeriodBounds(freq, localToday);
     const currentCount = await countPeriodCompletions(supabase, habitId, user.id, start, end);
 
     if (currentCount >= targetCount) {
@@ -433,7 +436,7 @@ export async function logHabitCompletion(
       .order("completed_at", { ascending: false });
 
     const completionDates = (allLogs || []).map((l) => l.completed_at);
-    const newStreak = computeUnifiedStreak(freq, targetCount, completionDates);
+    const newStreak = computeUnifiedStreak(freq, targetCount, completionDates, localToday);
 
     // Update streak_count in habits table
     await supabase
@@ -456,6 +459,7 @@ export async function logHabitCompletion(
 export async function removeHabitCompletion(
   habitId: number,
   date: string,
+  localToday?: string,
 ): Promise<ActionResponse<{ success: boolean }>> {
   try {
     const { supabase, user } = await getAuthenticatedUser();
@@ -492,7 +496,7 @@ export async function removeHabitCompletion(
       .order("completed_at", { ascending: false });
 
     const completionDates = (remainingLogs || []).map((l) => l.completed_at);
-    const newStreak = computeUnifiedStreak(freq as HabitFrequency, targetCount, completionDates);
+    const newStreak = computeUnifiedStreak(freq as HabitFrequency, targetCount, completionDates, localToday);
 
     // Update streak_count in habits table
     await supabase
@@ -514,7 +518,10 @@ export async function removeHabitCompletion(
 
 // === Statistics ===
 
-export async function getHabitStats(habitId: number): Promise<
+export async function getHabitStats(
+  habitId: number,
+  localToday?: string,
+): Promise<
   ActionResponse<{
     completion_rate_7d: number;
     completion_rate_30d: number;
@@ -593,7 +600,7 @@ export async function getHabitStats(habitId: number): Promise<
 
     // Unified streak
     const completionDates = (logs || []).map((log: HabitLog) => log.completed_at);
-    const currentStreak = computeUnifiedStreak(freq, targetCount, completionDates);
+    const currentStreak = computeUnifiedStreak(freq, targetCount, completionDates, localToday);
 
     // Rule-based prediction
     const prediction =

--- a/app/actions/journals.ts
+++ b/app/actions/journals.ts
@@ -96,6 +96,9 @@ export const createJournal = async (input: JournalInput) => {
       mood_tags: {
         mood: input.mood_tags || "neutral",
       },
+      // Timezone metadata for accurate day-boundary logic
+      ...(input.timezone && { timezone: input.timezone }),
+      ...(input.local_date && { local_date: input.local_date }),
     };
 
     // Include iv if provided (indicates encrypted content)

--- a/app/actions/ml.ts
+++ b/app/actions/ml.ts
@@ -48,9 +48,33 @@ export interface InsightResult {
   message?: string | null
 }
 
+function convertToLocalYYYYMMDD(utcString: string, timeZone?: string): string {
+  if (!timeZone || timeZone === "UTC") {
+    return utcString.slice(0, 10);
+  }
+  try {
+    const date = new Date(utcString);
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    const parts = formatter.formatToParts(date);
+    const year = parts.find(p => p.type === "year")?.value;
+    const month = parts.find(p => p.type === "month")?.value;
+    const day = parts.find(p => p.type === "day")?.value;
+    return `${year}-${month}-${day}`;
+  } catch (e) {
+    return utcString.slice(0, 10);
+  }
+}
+
 export async function fetchInsightsAction(params: {
   from: string
   to: string
+  user_timezone?: string
+  localToday?: string
 }): Promise<InsightResult> {
   if (!ML_ENDPOINT) {
     throw new Error("Insights service unavailable (missing endpoint)")
@@ -66,14 +90,16 @@ export async function fetchInsightsAction(params: {
     throw new Error("Not authenticated")
   }
 
-  const toDate = new Date()
-  const fromDate = new Date()
-  fromDate.setDate(toDate.getDate() - 90)
-  fromDate.setHours(0, 0, 0, 0)
-  toDate.setHours(23, 59, 59, 999)
+  const tz = params.user_timezone || "UTC";
+  const todayStr = params.localToday || new Date().toISOString().split("T")[0];
 
-  const fromIso = fromDate.toISOString()
-  const toIso = toDate.toISOString()
+  const toDate = new Date(`${todayStr}T23:59:59.999Z`);
+  const fromDate = new Date(`${todayStr}T00:00:00.000Z`);
+  fromDate.setUTCDate(fromDate.getUTCDate() - 90);
+
+  // Buffer 24h to avoid timezone boundary issues when querying UTC timestamptz
+  const queryFrom = new Date(fromDate.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const queryTo = new Date(toDate.getTime() + 24 * 60 * 60 * 1000).toISOString();
 
   const [tasksResult, habitLogsResult, journalsResult, moodResult, focusResult] =
     await Promise.all([
@@ -81,20 +107,20 @@ export async function fetchInsightsAction(params: {
         .from("tasks")
         .select("task_id, title, status, completed_at, created_at")
         .eq("user_id", user.id)
-        .gte("created_at", fromIso)
-        .lte("created_at", toIso),
+        .gte("created_at", queryFrom)
+        .lte("created_at", queryTo),
       supabase
         .from("habit_logs")
         .select("habit_id, completed_at")
         .eq("user_id", user.id)
-        .gte("completed_at", fromIso)
-        .lte("completed_at", toIso),
+        .gte("completed_at", queryFrom)
+        .lte("completed_at", queryTo),
       supabase
         .from("journals")
         .select("journal_id, title, content, sentiment_score, mood_tags, created_at, iv")
         .eq("user_id", user.id)
-        .gte("created_at", fromIso)
-        .lte("created_at", toIso),
+        .gte("created_at", queryFrom)
+        .lte("created_at", queryTo),
       supabase
         .from("mood_logs")
         .select("mood_score, note, logged_at")
@@ -106,8 +132,8 @@ export async function fetchInsightsAction(params: {
         .select("session_id, planned_duration, actual_duration, mood_before, mood_after, energy_start, energy_end, started_at, ended_at")
         .eq("user_id", user.id)
         .eq("is_active", false)
-        .gte("started_at", fromIso)
-        .lte("started_at", toIso),
+        .gte("started_at", queryFrom)
+        .lte("started_at", queryTo),
     ])
 
   // Build daily log entries grouped by date
@@ -123,7 +149,7 @@ export async function fetchInsightsAction(params: {
   }>()
 
   // Pre-fill every date in the range
-  for (let d = new Date(fromDate); d <= toDate; d.setDate(d.getDate() + 1)) {
+  for (let d = new Date(fromDate); d <= toDate; d.setUTCDate(d.getUTCDate() + 1)) {
     const key = d.toISOString().slice(0, 10)
     dayMap.set(key, {
       date: key, tasks_done: 0, tasks_created: 0, habits_completed: 0,
@@ -131,7 +157,10 @@ export async function fetchInsightsAction(params: {
     })
   }
 
-  const getDateKey = (value: string) => value.slice(0, 10)
+  const getDateKey = (value: string) => {
+    if (value.length === 10) return value;
+    return convertToLocalYYYYMMDD(value, tz);
+  }
 
   for (const task of tasksResult.data ?? []) {
     const key = getDateKey(task.created_at)

--- a/app/actions/moodLogs.ts
+++ b/app/actions/moodLogs.ts
@@ -40,6 +40,11 @@ function normalizeMoodScore(value: number) {
 }
 
 function normalizeLoggedAt(value?: string) {
+  // IMPORTANT: Client must provide local_date to avoid UTC day-boundary bugs.
+  // Fallback uses server time which may differ from user's local date.
+  if (!value) {
+    console.warn('[moodLogs] logged_at not provided — falling back to server date. Client should send getLocalDateString().')
+  }
   return value ?? new Date().toISOString().split('T')[0]
 }
 

--- a/components/activity/activity-page-client.tsx
+++ b/components/activity/activity-page-client.tsx
@@ -21,6 +21,7 @@ import {
 import Link from "next/link"
 import { usePremium } from "@/hooks/use-premium"
 import { fetchInsightsAction } from "@/app/actions/ml"
+import { getUserTimezone, getLocalDateString } from "@/lib/timezone"
 
 import {
   ACTIVITY_TYPE_OPTIONS,
@@ -742,6 +743,8 @@ function InsightsTab({
       const result = await fetchInsightsAction({
         from: range.from,
         to: range.to,
+        user_timezone: getUserTimezone(),
+        localToday: getLocalDateString(),
       })
 
       if (result.message && (!result.insights || result.insights.length === 0)) {

--- a/components/dashboard/dashboard-greeting.tsx
+++ b/components/dashboard/dashboard-greeting.tsx
@@ -1,0 +1,85 @@
+/**
+ * =============================================================================
+ * DASHBOARD GREETING (Client Component)
+ * =============================================================================
+ *
+ * Renders the time-aware greeting, subtitle, time icon, and formatted date.
+ * This MUST be a client component so it uses the browser's local time,
+ * not the server's timezone.
+ * =============================================================================
+ */
+
+"use client"
+
+import { useState, useEffect } from "react"
+import { Sun, CloudSun, Sunset, Moon } from "lucide-react"
+import { getCalmTimeGreeting } from "@/lib/greetings/getCalmTimeGreeting"
+import { getGentleSubtitle } from "@/lib/greetings/getGentleSubtitle"
+
+interface DashboardGreetingProps {
+  userName?: string | null
+}
+
+function getTimeIcon(hour: number) {
+  if (hour >= 5 && hour < 12) return CloudSun
+  if (hour >= 12 && hour < 17) return Sun
+  if (hour >= 17 && hour < 22) return Sunset
+  return Moon
+}
+
+export function DashboardGreeting({ userName }: DashboardGreetingProps) {
+  // Use state to avoid hydration mismatch — render neutral on first paint,
+  // then update to the correct local-time values after mount.
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Before mount, render a minimal skeleton to avoid hydration mismatch
+  if (!mounted) {
+    return (
+      <header className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div className="flex flex-col gap-1.5">
+          <div className="h-8 w-64 bg-muted/30 rounded-lg animate-pulse" />
+          <div className="h-5 w-48 bg-muted/20 rounded-lg animate-pulse" />
+        </div>
+        <div className="flex items-center gap-2.5 px-4 py-2.5 bg-card/60 backdrop-blur-sm border border-border/50 rounded-2xl shadow-sm shrink-0">
+          <div className="h-7 w-7 bg-muted/30 rounded-full animate-pulse" />
+          <div className="h-4 w-36 bg-muted/20 rounded animate-pulse" />
+        </div>
+      </header>
+    )
+  }
+
+  const hour = new Date().getHours()
+  const TimeIcon = getTimeIcon(hour)
+  const greeting = getCalmTimeGreeting(userName)
+  const subtitle = getGentleSubtitle()
+  const dateString = new Date().toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  })
+
+  return (
+    <header className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+      <div className="flex flex-col gap-1.5">
+        <h1 className="text-2xl md:text-3xl font-semibold font-primary tracking-tight text-foreground/90">
+          {greeting}
+        </h1>
+        <p className="text-muted-foreground text-sm md:text-base">
+          {subtitle}
+        </p>
+      </div>
+      <div className="flex items-center gap-2.5 px-4 py-2.5 bg-card/60 backdrop-blur-sm border border-border/50 rounded-2xl shadow-sm shrink-0">
+        <div className="p-1.5 bg-primary/10 rounded-full text-primary">
+          <TimeIcon className="w-4 h-4" />
+        </div>
+        <div className="text-sm font-medium text-muted-foreground/80">
+          {dateString}
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/dashboard/mood-input-card.tsx
+++ b/components/dashboard/mood-input-card.tsx
@@ -14,6 +14,7 @@ import {
   LucideIcon,
   ChevronRight
 } from "lucide-react";
+import { getLocalDateString } from "@/lib/timezone";
 import Link from "next/link";
 
 type MoodType = 'happy' | 'calm' | 'neutral' | 'sad' | 'frustrated' | 'excited' | 'anxious';
@@ -52,7 +53,7 @@ export function MoodInputCard() {
     if (stored) {
       try {
         const parsed: StoredMood = JSON.parse(stored);
-        const today = new Date().toISOString().split('T')[0];
+        const today = getLocalDateString();
         if (parsed.date === today) {
           setSelectedMood(parsed.mood);
         }
@@ -64,7 +65,7 @@ export function MoodInputCard() {
   }, []);
 
   const handleMoodSelect = (mood: MoodType) => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getLocalDateString();
     const data: StoredMood = { mood, date: today };
     localStorage.setItem(MOOD_STORAGE_KEY, JSON.stringify(data));
     setSelectedMood(mood);

--- a/components/dashboard/quick-journal-card.tsx
+++ b/components/dashboard/quick-journal-card.tsx
@@ -38,6 +38,7 @@ import { useRouter } from "next/navigation";
 import { Journal, MoodTags } from "@/types/database";
 import { createJournal } from "@/app/actions/journals";
 import { canCreateJournal } from "@/app/actions/usage-limits";
+import { getLocalDateString, getUserTimezone } from "@/lib/timezone";
 import { PremiumGateModal } from "@/components/premium-gate-modal";
 
 const QUICK_JOURNAL_KEY = "rhythme_quick_journal_draft";
@@ -56,7 +57,7 @@ function getRandomPrompt(): string {
 }
 
 function getTodayKey(): string {
-  return new Date().toISOString().split('T')[0];
+  return getLocalDateString();
 }
 
 // Normalized entry type for component use
@@ -152,6 +153,8 @@ export function QuickJournalCard({ journals }: QuickJournalCardProps) {
       mood_tags: "neutral",
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      timezone: getUserTimezone(),
+      local_date: getLocalDateString(),
     });
 
     if (result.error) {

--- a/components/weekly/weekly-page-client.tsx
+++ b/components/weekly/weekly-page-client.tsx
@@ -29,6 +29,7 @@ import { useWeeklyPlan, useSaveWeeklyPlan } from "@/hooks/use-weekly-plan"
 import { useWeeklyStats } from "@/hooks/use-weekly-stats"
 import { useWeeklyReview, useSaveWeeklyReview } from "@/hooks/use-weekly-review"
 import { fetchInsightsAction } from "@/app/actions/ml"
+import { getUserTimezone, getLocalDateString } from "@/lib/timezone"
 import { getLastWeekPlan } from "@/app/actions/weekly"
 import { toast } from "sonner"
 
@@ -135,7 +136,12 @@ export function WeeklyPageClient({ activeHabits, isPremium }: WeeklyPageClientPr
     
     setIsLoadingInsight(true)
     try {
-      const res = await fetchInsightsAction({ from: weekStart, to: weekEnd })
+      const res = await fetchInsightsAction({
+        from: weekStart,
+        to: weekEnd,
+        user_timezone: getUserTimezone(),
+        localToday: getLocalDateString(),
+      })
       if (res.insights && res.insights.length > 0) {
         const first = res.insights[0]
         setInsight(typeof first === 'string' ? first : (first.sentence || first.insight || "You are building strong habits."))

--- a/docs/6.4-behavioral-engine-first-proto.md
+++ b/docs/6.4-behavioral-engine-first-proto.md
@@ -1,0 +1,204 @@
+Rhythme Models 1
+Feature 6.4 --- Behavioral Pattern Insights
+Math, Logic & Storage Design
+1. What This Feature Does
+Feature 6.4 takes daily logs submitted by the user from the frontend, runs statistical correlation math on those logs, and returns a list of human-readable insight sentences. No data is saved. No ML model is involved. The entire analysis happens in memory per request.
+Input from frontend:
+•	journaled (0 or 1)
+•	tasks_done (number)
+•	mood (1 to 10)
+•	focus_mins (number)
+•	sentiment --- optional, includes label, confidence score, model name, emotions
+Output from API:
+•	A list of plain-English insight sentences (maximum 5)
+•	Number of days analyzed
+•	A message if there is not enough data or no patterns were found
+2. Why 14 Days Minimum
+Correlation math needs variance. If you only have 3 or 5 days of data, the numbers are too noisy to mean anything. A correlation result from 3 data points could be completely random.
+14 days is the practical minimum where:
+•	There is enough spread in the data to detect a real pattern
+•	The math does not produce misleadingly high correlations from noise
+•	The user has logged long enough for habits to form
+If fewer than 14 days are sent, the API returns an error immediately and skips all calculations.
+3. The Math --- Step by Step
+3.1 What Pairs Are Compared
+Every meaningful combination of the 4 columns is tested. That gives 6 base pairs:
+________________________________________
+Pair Signal A Signal B
+1 journaled tasks_done
+2 journaled mood
+3 journaled focus_mins
+4 mood tasks_done
+5 mood focus_mins
+6 tasks_done focus_mins
+________________________________________
+If sentiment data is present for 14 or more days, 3 additional pairs are added:
+•	sentiment_confidence vs mood
+•	sentiment_confidence vs tasks_done
+•	sentiment_confidence vs focus_mins
+3.2 Two Types of Correlation
+The method used depends on what type of data the two columns contain:
+________________________________________
+Situation Method When Used
+Both columns are Pearson Correlation mood, tasks_done, numbers focus_mins, sentiment_confidence
+One column is 0/1, Point-Biserial journaled vs anything other is a number Correlation
+________________________________________
+Both methods return a number between -1 and +1. This number is called the correlation coefficient (r).
+What r means:
+•	r = +1.0 Both columns move together perfectly --- when one goes up, the other always goes up
+•	r = -1.0 They move opposite --- when one goes up, the other always goes down
+•	r = 0.0 No relationship at all --- completely random
+•	r = +0.7 Strong positive pattern
+•	r = -0.5 Moderate negative pattern
+3.3 Pearson Correlation --- Explained Simply
+Pearson measures how consistently two number columns move together across all days.
+The formula in plain terms:
+r = (sum of: how far each x is from average x times how far each y is from average y)
+divided by
+(spread of x times spread of y)
+Real example with mood vs focus_mins over 5 days:
+________________________________________
+Day Mood Focus Mins Mood - Avg Focus - Avg
+1 8 60 +1.4 +12
+2 5 35 -1.6 -13
+3 7 50 +0.4 +2
+4 6 40 -0.6 -8
+5 9 65 +2.4 +17
+Average 6.6 48
+________________________________________
+Notice the pattern: on day 1 both mood and focus are above average. On day 2 both are below average. They consistently move together. The math would return an r close to +0.99 for this data.
+The resulting sentence would be:
+"You focus for longer when you start the day in a good mood."
+3.4 Point-Biserial --- Explained Simply
+Used when one column is journaled (0 or 1). Instead of tracking movement together, it compares averages.
+The formula in plain terms:
+r = (average of Y when journaled=1) minus (average of Y when journaled=0)
+divided by
+overall spread of Y times a correction factor for group sizes
+Real example --- journaled vs tasks_done over 8 days:
+________________________________________
+Days where journaled = 1 Days where journaled = 0
+tasks_done: 7, 6, 8, 5 tasks_done: 2, 3, 1, 2
+Average: 6.5 Average: 2.0
+________________________________________
+The average difference is large (6.5 vs 2.0). The spread across all 8 days is moderate. This produces a high r value --- around +0.85.
+The resulting sentence would be:
+"You complete more tasks on days you journal."
+3.5 Filtering Weak Results
+After calculating r for all pairs, anything where the absolute value is below 0.35 is thrown away.
+________________________________________
+r value What it means Kept or dropped
+0.81 Strong positive pattern Kept
+-0.62 Moderate negative Kept pattern
+0.28 Weak --- likely noise Dropped
+-0.10 No pattern Dropped
+________________________________________
+3.6 Ranking and Returning Top 5
+Surviving pairs are sorted by absolute r value --- strongest pattern first. The top 5 are picked. Each pair maps to a fixed sentence in a dictionary based on which two columns it is and whether the direction is positive or negative.
+Example ranking:
+mood vs focus_mins r = +0.81 → Positive → Sentence A
+journaled vs tasks_done r = +0.72 → Positive → Sentence B
+journaled vs mood r = -0.61 → Negative → Sentence C
+tasks_done vs focus_mins r = +0.40 → Positive → Sentence D
+4. How Sentiment Fits In
+Sentiment analysis is already built in the hybrid model. For Feature 6.4, only the confidence score from the sentiment result is used in the math.
+________________________________________
+Field from How it is used sentiment
+sentiment (label) Not used in math. Informational only.
+confidence (0.0 - 1.0) Used as a numeric column in Pearson correlation against mood, tasks_done, and focus_mins.
+emotions (dict) Not used in this feature.
+________________________________________
+Sentiment is optional per day. If fewer than 14 days have sentiment data, all sentiment pairs are skipped entirely. The base 6 pairs still run normally.
+5. The Storage Problem
+This is the most important architectural decision you have not made yet.
+The API needs 14+ days of data per request. The API itself does not store anything. So the question is: who holds the historical log data between sessions?
+5.1 Option A --- Frontend Stores Everything (localStorage)
+Every time the user logs a day, the Next.js app saves it to the browser's localStorage. When the user requests insights, the frontend reads all stored logs and sends them in the request body.
+________________________________________
+Advantages Problems
+Zero backend changes needed now User clears browser --- all data gone permanently
+Simple to implement on frontend Switch devices --- data does not follow
+Good enough for a prototype or demo Not viable for a real product
+________________________________________
+5.2 Option B --- Backend Stores Logs (Supabase)
+Each daily log is saved to a Supabase table when the user submits it. When insights are requested, the frontend sends only the user_id and the backend fetches the last 30 days automatically.
+________________________________________
+Advantages Problems
+Data is persistent and safe Requires adding a DB and auth to the backend
+Works across devices More work now
+Required for a real product Need user identity management
+________________________________________
+5.3 What to Do Right Now
+If this is a prototype or you are building to demo the feature:
+•	Use localStorage on the frontend
+•	Frontend sends all logs on every request
+•	The current API code works with zero changes
+If this will be used by real users:
+•	Add a daily_logs table to Supabase with columns: user_id, date, journaled, tasks_done, mood, focus_mins, sentiment_label, sentiment_confidence
+•	Add a POST /logs endpoint to save each day's entry
+•	Change the insights endpoint to accept user_id instead of the full logs array
+•	The insight_engine.py math code does not change at all
+5.4 Suggested Supabase Table (For When You Are Ready)
+CREATE TABLE daily_logs (
+id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+user_id UUID NOT NULL,
+date DATE NOT NULL,
+journaled SMALLINT NOT NULL DEFAULT 0,
+tasks_done INT NOT NULL DEFAULT 0,
+mood SMALLINT NOT NULL,
+focus_mins INT NOT NULL DEFAULT 0,
+sentiment_label VARCHAR(20),
+sentiment_conf FLOAT,
+created_at TIMESTAMPTZ DEFAULT now(),
+UNIQUE (user_id, date)
+);
+6. API Reference
+Endpoint
+POST /api/v1/insights
+Request Body
+{
+"logs": [
+{
+"date": "2024-03-31", // optional
+"journaled": 1, // 0 or 1
+"tasks_done": 5,
+"mood": 8, // 1 to 10
+"focus_mins": 45,
+"sentiment": { // optional
+"sentiment": "positive",
+"confidence": 0.87,
+"model_used": "roberta",
+"emotions": {}
+}
+}
+]
+}
+Response
+{
+"insights": [
+"You complete more tasks on days you journal.",
+"Your mood tends to be higher on days you journal."
+],
+"days_analyzed": 20,
+"message": null
+}
+Edge Case Responses
+________________________________________
+Situation Response
+Less than 14 days sent insights: [], message: "Need at least 14 days of data. You sent X."
+14+ days but all insights: [], message: "Not enough patterns patterns weak found yet. Keep logging more days."
+Empty body HTTP 400 --- No logs provided.
+________________________________________
+7. Files Created
+________________________________________
+File Purpose
+schemas_64.py Pydantic input/output models
+insight_engine.py All correlation math, filtering, sentence lookup
+routes_64.py FastAPI POST endpoint
+________________________________________
+To register the endpoint in main.py:
+from routes_64 import router as insights_router
+app.include_router(insights_router, prefix="/api/v1", tags=["insights"])
+Dependency to add to requirements.txt:
+scipy
+

--- a/lib/habit-helpers.ts
+++ b/lib/habit-helpers.ts
@@ -77,16 +77,20 @@ export function getStreakUnit(freq: HabitFrequency): string {
 }
 
 /**
- * Get the current period boundaries (UTC) for a given frequency.
- * Returns ISO strings suitable for Supabase range queries.
+ * Get the current period boundaries for a given frequency.
+ * Returns date strings suitable for Supabase range queries.
+ *
+ * @param freq - Habit frequency
+ * @param localToday - Optional local date string (YYYY-MM-DD) from the client.
+ *                     If omitted, falls back to UTC-based date (server context).
  */
-export function getPeriodBounds(freq: HabitFrequency): { start: string; end: string } {
+export function getPeriodBounds(freq: HabitFrequency, localToday?: string): { start: string; end: string } {
   const now = new Date();
 
   switch (freq) {
     case 0: {
-      // Daily: today 00:00 to 23:59:59.999 UTC
-      const dayStr = now.toISOString().split("T")[0];
+      // Daily: use client-provided local date if available, else UTC
+      const dayStr = localToday || now.toISOString().split("T")[0];
       return {
         start: `${dayStr}T00:00:00.000Z`,
         end: `${dayStr}T23:59:59.999Z`,
@@ -152,12 +156,19 @@ function getISOMonthKey(dateStr: string): string {
  * Compute a daily streak: consecutive days with >= targetCount completions.
  * dateStrs must be unique date strings in descending order.
  * dateCounts maps each date string to its completion count.
+ *
+ * @param todayOverride - Optional local "today" string. Falls back to UTC.
  */
-function computeDailyStreak(dateStrs: string[], dateCounts: Map<string, number>, targetCount: number): number {
+function computeDailyStreak(
+  dateStrs: string[],
+  dateCounts: Map<string, number>,
+  targetCount: number,
+  todayOverride?: string,
+): number {
   if (dateStrs.length === 0) return 0;
 
-  const today = new Date().toISOString().split("T")[0];
-  const yesterdayDate = new Date();
+  const today = todayOverride || new Date().toISOString().split("T")[0];
+  const yesterdayDate = new Date(`${today}T12:00:00Z`); // noon to avoid DST edge cases
   yesterdayDate.setUTCDate(yesterdayDate.getUTCDate() - 1);
   const yesterday = yesterdayDate.toISOString().split("T")[0];
 
@@ -287,12 +298,14 @@ function computeMonthlyStreak(dateStrs: string[], targetCount: number): number {
  * @param freq - habit frequency (0=daily, 1=weekly, 2=monthly, 3=multiple-per-week)
  * @param targetCount - required completions per period
  * @param completionDates - array of ISO date strings (completion timestamps), unsorted ok
+ * @param localToday - optional local "today" string (YYYY-MM-DD) from client
  * @returns current streak count
  */
 export function computeUnifiedStreak(
   freq: HabitFrequency,
   targetCount: number,
   completionDates: string[],
+  localToday?: string,
 ): number {
   if (completionDates.length === 0) return 0;
 
@@ -308,7 +321,7 @@ export function computeUnifiedStreak(
         dateCounts.set(d, (dateCounts.get(d) ?? 0) + 1);
       }
       const uniqueDatesDesc = [...new Set(sortedDesc)];
-      return computeDailyStreak(uniqueDatesDesc, dateCounts, targetCount);
+      return computeDailyStreak(uniqueDatesDesc, dateCounts, targetCount, localToday);
     }
     case 1:
     case 3:

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -1,0 +1,156 @@
+/**
+ * =============================================================================
+ * TIMEZONE UTILITIES
+ * =============================================================================
+ *
+ * Central module for all timezone-aware date operations in Rhythmé.
+ *
+ * CONVENTION:
+ *   - NEVER use `new Date().toISOString().split('T')[0]` to get "today".
+ *     Always use `getLocalDateString()` from this module.
+ *   - Store timestamps as UTC (`new Date().toISOString()`) — this is correct.
+ *   - Store `local_date` (YYYY-MM-DD) alongside timestamps when the user's
+ *     calendar day matters (journals, mood logs, daily habits).
+ *   - Store `timezone` (IANA string) on records where day-boundary matters.
+ *   - Server actions that need "today" must receive it from the client.
+ *   - ML endpoints must receive `user_timezone` and `local_date` explicitly.
+ *
+ * =============================================================================
+ */
+
+/**
+ * Returns the user's IANA timezone string from the browser.
+ * e.g. "Asia/Kolkata", "America/New_York", "Europe/London"
+ *
+ * Falls back to "UTC" in non-browser environments (SSR safety).
+ */
+export function getUserTimezone(): string {
+  if (typeof window === "undefined") return "UTC"
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone
+  } catch {
+    return "UTC"
+  }
+}
+
+/**
+ * Returns a date as "YYYY-MM-DD" in the user's local timezone.
+ * This is the ONLY correct way to get "today" for data operations.
+ *
+ * @param date - Optional Date object. Defaults to now.
+ * @returns e.g. "2026-05-21"
+ */
+export function getLocalDateString(date?: Date): string {
+  const d = date ?? new Date()
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
+/**
+ * Returns an ISO-ish string for the start of today in the user's local timezone.
+ * Useful for Supabase range queries where you want "today" relative to the user.
+ *
+ * @returns e.g. "2026-05-21T00:00:00.000" (no Z — local interpretation)
+ */
+export function getStartOfTodayISO(date?: Date): string {
+  const d = date ?? new Date()
+  const dateStr = getLocalDateString(d)
+  return `${dateStr}T00:00:00.000`
+}
+
+/**
+ * Returns an ISO-ish string for the end of today in the user's local timezone.
+ *
+ * @returns e.g. "2026-05-21T23:59:59.999"
+ */
+export function getEndOfTodayISO(date?: Date): string {
+  const d = date ?? new Date()
+  const dateStr = getLocalDateString(d)
+  return `${dateStr}T23:59:59.999`
+}
+
+/**
+ * Safely parses a UTC date string (even one lacking a 'Z' or offset) into a Date object.
+ */
+export function parseUTCDate(date: string | Date): Date {
+  if (date instanceof Date) return date;
+  if (!date) return new Date();
+
+  // If it's already an ISO string with Z or timezone offset at the end, parse it directly
+  if (date.endsWith("Z") || /[+-]\d{2}(:?\d{2})?$/.test(date)) {
+    return new Date(date);
+  }
+
+  // If it has 'T' separator, append 'Z'
+  if (date.includes("T")) {
+    return new Date(`${date}Z`);
+  }
+
+  // If it is in format "YYYY-MM-DD HH:MM:SS", convert to "YYYY-MM-DDTHH:MM:SSZ"
+  if (/^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}/.test(date)) {
+    return new Date(`${date.replace(" ", "T")}Z`);
+  }
+
+  // Fallback: append 'Z' if it doesn't look like it has offset/Z
+  return new Date(`${date}Z`);
+}
+
+/**
+ * Formats a date/timestamp for display in the user's local timezone.
+ * Returns a human-readable date string.
+ *
+ * @param date - ISO string or Date object
+ * @param options - Optional Intl.DateTimeFormat options
+ * @returns e.g. "May 21, 2026"
+ */
+export function toLocalDate(
+  date: string | Date,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  const d = parseUTCDate(date)
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    ...options,
+  })
+}
+
+/**
+ * Formats a date/timestamp to a full date and time string in the user's local timezone.
+ *
+ * @param date - ISO string or Date object
+ * @param options - Optional Intl.DateTimeFormat options
+ * @returns e.g. "5/21/2026, 9:20:11 PM"
+ */
+export function toLocalDateTimeString(
+  date: string | Date,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  const d = parseUTCDate(date)
+  return d.toLocaleString(undefined, options)
+}
+
+/**
+ * Returns UTC offset string for display purposes.
+ * e.g. "UTC+05:30", "UTC-04:00", "UTC+00:00"
+ */
+export function getUTCOffsetString(): string {
+  const offset = new Date().getTimezoneOffset() // in minutes, sign-inverted
+  const sign = offset <= 0 ? "+" : "-"
+  const absOffset = Math.abs(offset)
+  const hours = String(Math.floor(absOffset / 60)).padStart(2, "0")
+  const minutes = String(absOffset % 60).padStart(2, "0")
+  return `UTC${sign}${hours}:${minutes}`
+}
+
+/**
+ * Returns the user's local hour (0-23). SSR-safe.
+ * On the server, returns -1 to signal "unknown".
+ */
+export function getLocalHour(): number {
+  if (typeof window === "undefined") return -1
+  return new Date().getHours()
+}

--- a/types/database.ts
+++ b/types/database.ts
@@ -178,6 +178,8 @@ export interface JournalInput {
   mood_tags?: MoodTags;
   created_at?: string;
   updated_at?: string;
+  timezone?: string; // IANA timezone string, e.g. "Asia/Kolkata"
+  local_date?: string; // User's local date as YYYY-MM-DD
 }
 
 export type MoodTags = "happy" | "calm" | "neutral" | "sad" | "frustrated" | "excited" | "anxious"


### PR DESCRIPTION
Add centralized timezone utilities and propagate local-date/time handling across the app to fix UTC day-boundary bugs. Introduces lib/timezone with helpers (getLocalDateString, getUserTimezone, toLocalDateTimeString, parseUTCDate, getUTCOffsetString, etc.). Update server actions and helpers to accept client-provided localToday/user_timezone (habits, journals, ml, moodLogs) and adjust period bounds, streak computation, and ML query ranges to be timezone-safe. Add DashboardGreeting client component to render time-aware greeting without hydration mismatches and surface timezone info in GeneralSection. Update components (mood input, quick journal, weekly/activity insights) to send/consume local_date and timezone. Add types for timezone/local_date and a docs prototype for the behavioral engine.