### PR TITLE
Limit task/habit deletions to the current goal

### DIFF
--- a/app/onboarding/_hooks/useOnboarding.ts
+++ b/app/onboarding/_hooks/useOnboarding.ts
@@ -303,9 +303,18 @@ export function useOnboarding() {
 
       if (goalError) throw goalError
 
-      // Delete existing tasks and habits for this user to avoid duplicates on retry
-      await supabase.from('tasks').delete().eq('user_id', userId)
-      await supabase.from('habits').delete().eq('user_id', userId)
+      // Delete existing tasks and habits linked to this goal to avoid duplicates on retry
+      await supabase
+        .from('tasks')
+        .delete()
+        .eq('user_id', userId)
+        .eq('goal_id', goal.id)
+
+      await supabase
+        .from('habits')
+        .delete()
+        .eq('user_id', userId)
+        .eq('goal_id', goal.id)
 
       // 3. Insert tasks
       const tasksToInsert = tasks


### PR DESCRIPTION
Previously the onboarding flow deleted all tasks and habits for the user on retry, which could remove unrelated data. Update the Supabase delete queries in app/onboarding/_hooks/useOnboarding.ts to include .eq('goal_id', goal.id) so only items linked to the created goal are removed, preventing unintended data loss and avoiding duplicates.