### PR TITLE
Add premium paywall, pricing & habit limit

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { Separator } from "@/components/ui/separator"
 import { getUser } from "../../actions/auth"
 import { getJournals } from "@/app/actions/journals"
 import { DashboardGreeting } from "@/components/dashboard/dashboard-greeting"
+import { isCurrentUserPremium } from "@/app/actions/subscription"
 
 // Dashboard components
 import {
@@ -25,11 +26,13 @@ import {
   MoodChartSkeleton,
   SentimentChartSkeleton,
   QuickActionsFab,
+  PremiumUpsellBanner,
 } from "@/components/dashboard"
 
 export default async function DashboardPage() {
   const user = await getUser()
   const journals = await getJournals()
+  const isPremium = await isCurrentUserPremium()
 
   return (
     <>
@@ -42,6 +45,9 @@ export default async function DashboardPage() {
             <DashboardGreeting userName={user?.name} />
 
             <Separator className="my-2" />
+
+            {/* Premium Upsell for Free Users */}
+            {!isPremium && <PremiumUpsellBanner />}
 
             {/* Daily Reflection Prompt */}
             <Suspense fallback={<ReflectionPromptSkeleton />}>

--- a/app/(app)/settings/billing/billing-settings-content.tsx
+++ b/app/(app)/settings/billing/billing-settings-content.tsx
@@ -43,7 +43,7 @@ const pricing = {
 
 const starterPlanFeatures = [
   "1 Goal workspace",
-  "Track up to 3 habits",
+  "Track up to 5 habits",
   "10 tasks per day",
   "10 journal entries/month",
   "Basic focus timer",
@@ -383,13 +383,12 @@ export default function BillingSettingsContent({ currentPlan }: BillingSettingsC
                         </>
                       ) : (
                         <>
-                          <Sparkles className="h-4 w-4" />
-                          Upgrade Now
+                          Go Premium
                         </>
                       )}
                     </Button>
                     <p className="text-xs text-center text-muted-foreground">
-                      30-day money-back guarantee
+                      Cancel anytime · Your data stays yours
                     </p>
                   </div>
                 </div>

--- a/app/(app)/settings/subscription/_components/subscription-section.tsx
+++ b/app/(app)/settings/subscription/_components/subscription-section.tsx
@@ -1,77 +1,80 @@
-// app/(dashboard)/settings/subscription/_components/subscription-section.tsx
-// Subscription management with Dodo Payments checkout integration
-
 "use client"
 
 import { useState } from "react"
+import { useSearchParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Switch } from "@/components/ui/switch"
-import { 
-  Sparkles, 
-  Check,
-  Zap,
-  Brain,
-  Cloud,
-  Shield,
-  TrendingUp,
+import {
   Crown,
+  Sparkles,
   Calendar,
   Receipt,
-  Target,
-  Rocket,
-  Flame,
-  Heart,
-  Compass,
-  BarChart3,
-  Palette,
-  ChevronDown,
-  ChevronUp,
-  Loader2,
+  TrendingUp,
   CreditCard,
   AlertTriangle,
+  Loader2,
+  Check,
+  X,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { motion, AnimatePresence } from "framer-motion"
 import { toast } from "sonner"
 
-// Display pricing. Dodo product ids remain the source of truth for actual charges.
 const pricing = {
-  monthly: { starter: 0, premium: 9.99 },
-  yearly: { starter: 0, premium: 99.99 }
+  monthly: 9.99,
+  yearly: 99.99,
 }
 
 const starterPlanFeatures = [
   "1 Goal workspace",
-  "Track up to 3 habits",
+  "Track up to 5 habits",
   "10 tasks per day",
   "10 journal entries/month",
   "Basic focus timer",
 ]
 
-interface PremiumFeature {
-  text: string
-  icon: React.ElementType
-  inDevelopment?: boolean
+const benefits = [
+  {
+    heading: "No more choosing what to track",
+    description: "Unlimited habits, tasks, journals, and mood logs. Your full picture — always complete, never capped.",
+  },
+  {
+    heading: "Patterns you'd never catch alone",
+    description: "Weekly behavioral reviews and analytics that reveal when you do your best work — and what quietly derails you.",
+  },
+  {
+    heading: "Intelligence that adapts to your rhythm",
+    description: "Predictive habit insights, smart suggestions, and sentiment analysis that sharpen with every day you show up.",
+  },
+  {
+    heading: "A workspace that feels like yours",
+    description: "Premium themes, multiple goal workspaces, and early access to everything we build next.",
+  },
+]
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.15,
+    },
+  },
 }
 
-const premiumFeatures: PremiumFeature[] = [
-  { text: "Unlimited workspaces", icon: Target },
-  { text: "Unlimited habits & tasks", icon: Zap },
-  { text: "Unlimited journaling", icon: Sparkles },
-  { text: "Rhythmé AI Agent", icon: Brain, inDevelopment: true },
-  { text: "NBA Engine (Full Access)", icon: Rocket, inDevelopment: true },
-  { text: "Journal Sentiment Analysis", icon: Heart, inDevelopment: true },
-  { text: "AI Goal Roadmaps", icon: Compass, inDevelopment: true },
-  { text: "Smart Task Generation", icon: Sparkles, inDevelopment: true },
-  { text: "Habit Suggestions", icon: Flame, inDevelopment: true },
-  { text: "Weekly & monthly insights", icon: TrendingUp },
-  { text: "Advanced analytics", icon: BarChart3 },
-  { text: "Cloud backup & sync", icon: Cloud },
-  { text: "Priority support", icon: Shield },
-  { text: "Custom themes", icon: Palette },
-  { text: "Early access to features", icon: Crown },
-]
+const itemVariants = {
+  hidden: { opacity: 0, y: -20 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      type: "spring" as const,
+      stiffness: 100,
+      damping: 15,
+    },
+  },
+}
 
 interface SubscriptionSectionProps {
   currentPlan: "starter" | "premium"
@@ -110,19 +113,20 @@ function formatMoney(amount?: number | string | null, currency = "USD") {
 }
 
 export function SubscriptionSection({ currentPlan, details }: SubscriptionSectionProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const justUpgraded = searchParams.get("upgraded") === "true"
+
   const [billingCycle, setBillingCycle] = useState<"monthly" | "yearly">("yearly")
-  const [showAllFeatures, setShowAllFeatures] = useState(false)
   const [isUpgrading, setIsUpgrading] = useState(false)
   const [isUpdatingPayment, setIsUpdatingPayment] = useState(false)
   const [isCancelling, setIsCancelling] = useState(false)
-  
+
+  // Custom paywall UI states
+  const [showPaywall, setShowPaywall] = useState(false)
+  const [checkoutStep, setCheckoutStep] = useState<1 | 2>(1)
+
   const isPremium = currentPlan === "premium"
-  const yearlyPrice = pricing.yearly.premium
-  const monthlyPrice = pricing.monthly.premium
-  const monthlySavings = (monthlyPrice * 12) - yearlyPrice
-  const savingsPercentage = Math.round((monthlySavings / (monthlyPrice * 12)) * 100)
-  
-  const visibleFeatures = showAllFeatures ? premiumFeatures : premiumFeatures.slice(0, 6)
   const renewalDate = details?.currentPeriodEnd ? new Date(details.currentPeriodEnd) : null
   const daysUntilRenewal = renewalDate
     ? Math.max(0, Math.ceil((renewalDate.getTime() - new Date().getTime()) / (1000 * 3600 * 24)))
@@ -130,7 +134,7 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
 
   const handleUpgrade = async () => {
     setIsUpgrading(true)
-    
+
     try {
       const res = await fetch("/api/payments/create-subscription", {
         method: "POST",
@@ -212,239 +216,338 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
   }
 
   return (
-    <div className="space-y-8">
-      {/* Current Plan */}
-      <section className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            {isPremium ? (
-              <Crown className="h-5 w-5 text-primary" />
-            ) : (
-              <Target className="h-5 w-5 text-muted-foreground" />
-            )}
-            <h3 className="font-medium">
-              {isPremium ? "Premium Plan" : "Starter Plan"}
-            </h3>
-          </div>
-          <Badge variant={isPremium ? "default" : "secondary"}>
-            {isPremium ? (details?.cancelAtPeriodEnd ? "Cancels soon" : "Active") : "Current"}
-          </Badge>
-        </div>
-        
-        <div className={cn(
-          "p-4 rounded-lg border",
-          isPremium 
-            ? "bg-primary/5 border-primary/30" 
-            : "bg-muted/30 border-border/50"
-        )}>
-          <p className="text-sm text-muted-foreground mb-3">
-            {isPremium 
-              ? "You have access to all premium features" 
-              : "Upgrade to unlock AI-powered features"
-            }
+    <div className="space-y-8 relative">
+      {/* Search param upgrade success banner */}
+      {justUpgraded && isPremium && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="p-6 rounded-xl border border-primary/30 bg-primary/5 text-center space-y-2 mb-6"
+        >
+          <h3 className="text-xl font-primary font-semibold">You&apos;re in.</h3>
+          <p className="text-sm text-muted-foreground">
+            Rhythmé Premium is active. Every tool, every insight, every capability — unlocked.
           </p>
-          
-          <div className="grid grid-cols-2 gap-2 text-sm">
-            {(isPremium ? premiumFeatures.slice(0, 4) : starterPlanFeatures).map((feature, i) => (
-              <div key={i} className="flex items-center gap-2">
-                <Check className="h-4 w-4 text-primary" />
-                <span className="text-muted-foreground">
-                  {typeof feature === "string" ? feature : feature.text}
-                </span>
-              </div>
-            ))}
-          </div>
-          
-          {isPremium && (
-            <div className="flex flex-col gap-3 pt-4 mt-4 border-t border-border/50 text-sm text-muted-foreground">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Calendar className="h-4 w-4" />
-                  <span className="capitalize">
-                    {details?.status || "active"} subscription {details?.plan ? `(${details.plan})` : ""}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Receipt className="h-4 w-4" />
-                  <span>{formatMoney(details?.amount, details?.currency || "USD")}/{details?.billingInterval || details?.plan || "period"}</span>
-                </div>
-              </div>
-              {renewalDate && (
-                <div className="flex items-center gap-2">
-                  <TrendingUp className="h-4 w-4" />
-                  <span>
-                    <strong className="text-foreground">{daysUntilRenewal} days left</strong>
-                    {details?.cancelAtPeriodEnd ? " until access ends" : " until renewal"}
-                  </span>
-                </div>
-              )}
-              {details?.cancelAtPeriodEnd && (
-                <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
-                  <AlertTriangle className="h-4 w-4" />
-                  <span>Your subscription is scheduled to cancel at period end.</span>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </section>
+        </motion.div>
+      )}
 
-      {/* Upgrade Section - Only for starter */}
+      {/* For Free/Starter Users: Normal Settings layout showing Current Plan & Get Premium Card */}
       {!isPremium && (
-        <>
+        <div className="space-y-8">
+          {/* Upgrade Promo Section */}
+          <div className="rounded-2xl border border-primary/20 bg-gradient-to-b from-primary/[0.03] to-primary/[0.01] p-6 md:p-8 space-y-6">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-primary font-semibold text-sm">
+                <Sparkles className="h-4 w-4" />
+                <span>Unlock Rhythmé Premium</span>
+              </div>
+              <h3 className="font-primary text-xl md:text-2xl font-semibold text-foreground">
+                Ready for the next level?
+              </h3>
+              <p className="text-sm text-muted-foreground max-w-xl leading-relaxed">
+                Get unlimited habits, tasks, journals, weekly reviews, AI-powered behavioral insights, identity reinforcement, and custom appearance settings.
+              </p>
+            </div>
+            
+            <Button
+              size="lg"
+              className="bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/10 px-8 py-6 rounded-xl font-medium"
+              onClick={() => {
+                setShowPaywall(true)
+                setCheckoutStep(1)
+              }}
+            >
+              Get Rhythmé Premium
+            </Button>
+          </div>
+
           <div className="border-b border-border/50" />
-          
-          <section className="space-y-6">
-            <div className="flex items-center justify-between flex-wrap gap-4">
+
+          {/* Current Starter Plan Info */}
+          <div className="space-y-6">
+            <div className="flex items-center justify-between pb-4 border-b border-border/50">
               <div>
-                <h3 className="font-medium flex items-center gap-2">
-                  <Sparkles className="h-4 w-4 text-primary" />
-                  Upgrade to Premium
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  Unlock unlimited features and AI-powered insights
-                </p>
+                <p className="text-xs text-muted-foreground uppercase tracking-wider font-semibold">Current Plan</p>
+                <h4 className="text-lg font-semibold text-foreground mt-1">Starter (Free)</h4>
               </div>
-              
-              {/* Billing Toggle */}
-              <div className="flex items-center gap-3">
-                <span className={cn(
-                  "text-sm font-medium transition-colors",
-                  billingCycle === "monthly" ? "text-foreground" : "text-muted-foreground"
-                )}>
-                  Monthly
-                </span>
-                <Switch
-                  checked={billingCycle === "yearly"}
-                  onCheckedChange={(checked) => setBillingCycle(checked ? "yearly" : "monthly")}
-                />
-                <span className={cn(
-                  "text-sm font-medium transition-colors",
-                  billingCycle === "yearly" ? "text-foreground" : "text-muted-foreground"
-                )}>
-                  Yearly
-                </span>
-                <AnimatePresence mode="wait">
-                  {billingCycle === "yearly" && (
-                    <motion.div
-                      initial={{ opacity: 0, scale: 0.8 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      exit={{ opacity: 0, scale: 0.8 }}
-                    >
-                      <Badge variant="secondary" className="text-xs bg-green-500/10 text-green-500 hover:bg-green-500/20">
-                        Save {savingsPercentage}%
-                      </Badge>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
+              <Badge variant="outline" className="px-2.5 py-0.5 text-xs bg-muted/30">
+                Active
+              </Badge>
             </div>
 
-            {/* Premium Card */}
-            <div className="p-6 rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 to-accent/5">
-              <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-6">
-                <div className="space-y-4 flex-1">
-                  {/* Price */}
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 rounded-lg bg-primary/10">
-                      <Sparkles className="h-6 w-6 text-primary" />
-                    </div>
-                    <div>
-                      <h4 className="text-xl font-bold flex items-center gap-2">
-                        Premium
-                        <Crown className="h-4 w-4 text-accent" />
-                      </h4>
-                      <div className="flex items-baseline gap-1">
-                        <span className="text-3xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
-                          ${billingCycle === "yearly" ? yearlyPrice : monthlyPrice}
-                        </span>
-                        <span className="text-muted-foreground">
-                          /{billingCycle === "yearly" ? "year" : "month"}
-                        </span>
-                      </div>
-                      {billingCycle === "yearly" && (
-                        <p className="text-sm text-primary">
-                          ${(yearlyPrice / 12).toFixed(2)}/month billed yearly
-                        </p>
-                      )}
-                    </div>
+            <div className="space-y-3">
+              <p className="text-xs text-muted-foreground uppercase tracking-wider font-semibold">
+                Included in your Starter plan:
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {starterPlanFeatures.map((feature, index) => (
+                  <div key={index} className="flex items-center gap-2.5 text-sm text-muted-foreground">
+                    <Check className="h-4 w-4 text-emerald-500 shrink-0" />
+                    <span>{feature}</span>
                   </div>
-                  
-                  {/* Features */}
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-                    {visibleFeatures.map((feature, i) => {
-                      const Icon = feature.icon
-                      return (
-                        <motion.div 
-                          key={i} 
-                          initial={{ opacity: 0, x: -5 }}
-                          animate={{ opacity: 1, x: 0 }}
-                          transition={{ delay: i * 0.03 }}
-                          className="flex items-center gap-2"
-                        >
-                          <Icon className="h-4 w-4 text-primary shrink-0" />
-                          <span className="text-muted-foreground">{feature.text}</span>
-                          {feature.inDevelopment && (
-                            <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-amber-500/10 text-amber-500 border border-amber-500/20">
-                              Dev
-                            </span>
-                          )}
-                        </motion.div>
-                      )
-                    })}
-                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
 
-                  {premiumFeatures.length > 6 && (
-                    <button
-                      onClick={() => setShowAllFeatures(!showAllFeatures)}
-                      className="text-sm text-primary font-medium flex items-center gap-1 hover:underline"
-                    >
-                      {showAllFeatures ? (
-                        <>Show Less <ChevronUp className="w-3 h-3" /></>
-                      ) : (
-                        <>Show All {premiumFeatures.length} Features <ChevronDown className="w-3 h-3" /></>
-                      )}
-                    </button>
-                  )}
-                </div>
-                
-                <div className="flex flex-col gap-2 md:min-w-[200px]">
-                  <Button 
-                    size="lg" 
-                    className="gap-2 bg-gradient-to-r from-primary to-accent hover:opacity-90 shadow-lg shadow-primary/25"
-                    onClick={handleUpgrade}
-                    disabled={isUpgrading}
+          {/* Animated Full Screen Paywall overlay */}
+          <AnimatePresence>
+            {showPaywall && (
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="fixed inset-0 z-50 bg-background flex flex-col items-center justify-start overflow-y-auto px-6 py-12 md:py-20"
+              >
+                <div className="w-full max-w-5xl relative flex-1 flex flex-col justify-center">
+                  
+                  {/* Close button */}
+                  <button
+                    onClick={() => setShowPaywall(false)}
+                    className="absolute top-0 right-0 p-2.5 rounded-full hover:bg-muted/80 transition-colors text-muted-foreground hover:text-foreground z-10"
+                    aria-label="Close paywall"
                   >
-                    {isUpgrading ? (
-                      <>
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        Processing...
-                      </>
+                    <X className="h-6 w-6" />
+                  </button>
+
+                  <AnimatePresence mode="wait">
+                    {checkoutStep === 1 ? (
+                      <motion.div
+                        key="paywall-step1"
+                        initial={{ opacity: 0, scale: 0.99 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.99 }}
+                        className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-center w-full"
+                      >
+                        {/* Left side: Hero & Features */}
+                        <div className="lg:col-span-7 space-y-8 text-left">
+                          <div className="space-y-3">
+                            <h2 className="font-primary text-3xl md:text-5xl font-semibold tracking-tight leading-[1.1] text-foreground">
+                              Go deeper into how you work.
+                            </h2>
+                            <p className="text-muted-foreground text-sm md:text-base max-w-lg leading-relaxed">
+                              Rhythmé Premium is the complete behavioral system for builders who take consistency seriously.
+                            </p>
+                          </div>
+
+                          {/* Drop-in animations for features one-by-one */}
+                          <motion.div
+                            variants={containerVariants}
+                            initial="hidden"
+                            animate="show"
+                            className="space-y-3"
+                          >
+                            {benefits.map((benefit, index) => (
+                              <motion.div
+                                key={index}
+                                variants={itemVariants}
+                                className="p-5 rounded-xl border border-border/40 bg-muted/20 backdrop-blur-sm"
+                              >
+                                <h3 className="text-sm font-semibold text-foreground">{benefit.heading}</h3>
+                                <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
+                                  {benefit.description}
+                                </p>
+                              </motion.div>
+                            ))}
+                          </motion.div>
+                        </div>
+
+                        {/* Right side: Pricing card */}
+                        <div className="lg:col-span-5">
+                          <div className="p-6 md:p-8 rounded-2xl border border-primary/25 space-y-6 bg-muted/10 backdrop-blur-sm relative overflow-hidden shadow-xl text-left">
+                            <div className="flex items-center justify-between">
+                              <span className="text-sm font-medium text-muted-foreground">Select Cycle</span>
+                              <div className="flex items-center gap-3">
+                                <span className={cn(
+                                  "text-xs font-medium transition-colors",
+                                  billingCycle === "monthly" ? "text-foreground" : "text-muted-foreground"
+                                  )}>
+                                  Monthly
+                                </span>
+                                <Switch
+                                  checked={billingCycle === "yearly"}
+                                  onCheckedChange={(checked) => setBillingCycle(checked ? "yearly" : "monthly")}
+                                />
+                                <span className={cn(
+                                  "text-xs font-medium transition-colors",
+                                  billingCycle === "yearly" ? "text-foreground" : "text-muted-foreground"
+                                )}>
+                                  Yearly
+                                </span>
+                              </div>
+                            </div>
+
+                            {billingCycle === "yearly" && (
+                              <p className="text-xs text-primary font-medium">Most builders choose annual</p>
+                            )}
+
+                            <div className="flex items-baseline gap-1">
+                              <span className="text-4xl md:text-5xl font-bold text-foreground">
+                                ${billingCycle === "yearly" ? pricing.yearly : pricing.monthly}
+                              </span>
+                              <span className="text-muted-foreground text-sm">
+                                /{billingCycle === "yearly" ? "year" : "month"}
+                              </span>
+                            </div>
+
+                            {billingCycle === "yearly" && (
+                              <p className="text-xs text-muted-foreground">
+                                ${(pricing.yearly / 12).toFixed(2)}/month, billed annually
+                              </p>
+                            )}
+
+                            <Button
+                              size="lg"
+                              className="w-full gap-2 bg-primary text-primary-foreground hover:bg-primary/90 mt-2 py-6 rounded-xl text-base"
+                              onClick={() => setCheckoutStep(2)}
+                            >
+                              <Sparkles className="h-4 w-4" />
+                              Go Premium
+                            </Button>
+                            <p className="text-[11px] text-center text-muted-foreground/80">
+                              Cancel anytime · Your data stays yours
+                            </p>
+                          </div>
+                        </div>
+                      </motion.div>
                     ) : (
-                      <>
-                        <Sparkles className="h-4 w-4" />
-                        Upgrade Now
-                      </>
+                      <motion.div
+                        key="paywall-step2"
+                        initial={{ opacity: 0, scale: 0.99 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.99 }}
+                        className="w-full max-w-md mx-auto space-y-6 text-left"
+                      >
+                        {/* Header */}
+                        <div className="text-center space-y-2">
+                          <h2 className="font-primary text-2xl font-semibold tracking-tight text-foreground">Confirm Subscription</h2>
+                          <p className="text-muted-foreground text-sm">Review your selected subscription cycle</p>
+                        </div>
+
+                        {/* Summary Card */}
+                        <div className="p-6 rounded-xl border border-primary/20 space-y-4 bg-muted/10">
+                          <div className="flex justify-between items-center pb-3 border-b border-border/40">
+                            <span className="font-semibold text-foreground">Rhythmé Premium</span>
+                            <Badge variant="outline" className="capitalize">
+                              {billingCycle === "yearly" ? "Annual" : "Monthly"}
+                            </Badge>
+                          </div>
+
+                          <div className="space-y-2 text-sm">
+                            <div className="flex justify-between text-muted-foreground">
+                              <span>Billing Interval</span>
+                              <span>{billingCycle === "yearly" ? "Every 12 months" : "Every month"}</span>
+                            </div>
+                            <div className="flex justify-between text-muted-foreground">
+                              <span>Price</span>
+                              <span>${billingCycle === "yearly" ? pricing.yearly : pricing.monthly}</span>
+                            </div>
+                            <div className="flex justify-between font-medium text-foreground pt-2 border-t border-border/40 text-base">
+                              <span>Total due today</span>
+                              <span>${billingCycle === "yearly" ? pricing.yearly : pricing.monthly}</span>
+                            </div>
+                          </div>
+
+                          <Button
+                            size="lg"
+                            className="w-full gap-2 bg-primary text-primary-foreground hover:bg-primary/90 mt-4 py-6 rounded-xl text-base"
+                            onClick={handleUpgrade}
+                            disabled={isUpgrading}
+                          >
+                            {isUpgrading ? (
+                              <>
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                Redirecting to Checkout...
+                              </>
+                            ) : (
+                              <>
+                                Continue to Checkout
+                              </>
+                            )}
+                          </Button>
+
+                          <Button
+                            variant="ghost"
+                            type="button"
+                            className="w-full text-xs text-muted-foreground hover:text-foreground"
+                            onClick={() => setCheckoutStep(1)}
+                            disabled={isUpgrading}
+                          >
+                            Back to pricing
+                          </Button>
+                        </div>
+
+                        <p className="text-xs text-muted-foreground/60 text-center">
+                          Payments secured by Dodo
+                        </p>
+                      </motion.div>
                     )}
-                  </Button>
-                  <p className="text-xs text-center text-muted-foreground">
-                    30-day money-back guarantee
-                  </p>
+                  </AnimatePresence>
                 </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      )}
+
+      {/* For Premium Users: Normal Subscription Management layout */}
+      {isPremium && (
+        <>
+          {/* Current Plan info */}
+          <section className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Crown className="h-5 w-5 text-primary" />
+                <h3 className="font-medium">Current Plan: Premium</h3>
+              </div>
+              <Badge variant="default">
+                {details?.cancelAtPeriodEnd ? "Cancels soon" : "Active"}
+              </Badge>
+            </div>
+
+            <div className="p-4 rounded-lg border bg-primary/5 border-primary/30">
+              <p className="text-sm text-muted-foreground mb-3">
+                You have access to all premium features
+              </p>
+
+              <div className="flex flex-col gap-3 pt-4 mt-4 border-t border-border/50 text-sm text-muted-foreground">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Calendar className="h-4 w-4" />
+                    <span className="capitalize">
+                      {details?.status || "active"} subscription {details?.plan ? `(${details.plan})` : ""}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Receipt className="h-4 w-4" />
+                    <span>{formatMoney(details?.amount, details?.currency || "USD")}/{details?.billingInterval || details?.plan || "period"}</span>
+                  </div>
+                </div>
+                {renewalDate && (
+                  <div className="flex items-center gap-2">
+                    <TrendingUp className="h-4 w-4" />
+                    <span>
+                      <strong className="text-foreground">{daysUntilRenewal} days left</strong>
+                      {details?.cancelAtPeriodEnd ? " until access ends" : " until renewal"}
+                    </span>
+                  </div>
+                )}
+                {details?.cancelAtPeriodEnd && (
+                  <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="h-4 w-4" />
+                    <span>Your subscription is scheduled to cancel at period end.</span>
+                  </div>
+                )}
               </div>
             </div>
           </section>
-        </>
-      )}
 
-      {/* Premium Actions */}
-      {isPremium && (
-        <>
           <div className="border-b border-border/50" />
-          
+
+          {/* Manage Subscription */}
           <section className="space-y-3">
             <h3 className="font-medium">Manage Subscription</h3>
-            
+
             <div className="flex items-center justify-between p-4 rounded-lg bg-muted/30 border border-border/50">
               <div>
                 <p className="font-medium text-sm">Update Payment Method</p>
@@ -455,7 +558,7 @@ export function SubscriptionSection({ currentPlan, details }: SubscriptionSectio
                 <span className="ml-2">Update</span>
               </Button>
             </div>
-            
+
             <div className="flex items-center justify-between p-4 rounded-lg bg-destructive/5 border border-destructive/20">
               <div>
                 <p className="font-medium text-sm text-destructive">Cancel Subscription</p>

--- a/app/(app)/welcome-premium/page.tsx
+++ b/app/(app)/welcome-premium/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { SiteHeader } from "@/components/site-header";
+import { motion } from "framer-motion";
+import { ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function WelcomePremiumPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push("/dashboard");
+    }, 8000);
+    return () => clearTimeout(timer);
+  }, [router]);
+
+  return (
+    <>
+      <SiteHeader />
+      <div className="flex flex-1 flex-col items-center justify-center px-6 pb-16">
+        <div className="max-w-md w-full text-center space-y-8">
+          <motion.div
+            initial={{ scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ type: "spring", stiffness: 300, damping: 20, delay: 0.1 }}
+            className="mx-auto flex h-20 w-20 items-center justify-center rounded-3xl bg-primary/10 border border-primary/20"
+          >
+            <motion.span
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ type: "spring", stiffness: 400, damping: 15, delay: 0.3 }}
+              className="text-4xl"
+            >
+              ✦
+            </motion.span>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 15 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.4 }}
+            className="space-y-3"
+          >
+            <h1 className="text-3xl md:text-4xl font-primary font-semibold tracking-tight">
+              You&apos;re in.
+            </h1>
+            <p className="text-muted-foreground text-base leading-relaxed">
+              Rhythmé Premium is active. Every tool, every insight, every
+              capability — unlocked.
+            </p>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 15 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.6 }}
+            className="space-y-3 text-left"
+          >
+            <div className="p-4 rounded-xl border border-border/40 bg-muted/20 space-y-3">
+              {[
+                "Your habit and task limits have been removed",
+                "Behavioral insights and weekly reviews are now available",
+                "Explore premium themes in Settings → Appearance",
+              ].map((item, i) => (
+                <div key={i} className="flex items-start gap-3">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary shrink-0" />
+                  <span className="text-sm text-muted-foreground">{item}</span>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 15 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.8 }}
+          >
+            <Button
+              size="lg"
+              className="w-full gap-2"
+              onClick={() => router.push("/dashboard")}
+            >
+              Continue building
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+            <p className="text-xs text-muted-foreground/60 mt-3">
+              Redirecting to your dashboard shortly
+            </p>
+          </motion.div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/actions/usage-limits.ts
+++ b/app/actions/usage-limits.ts
@@ -64,13 +64,13 @@ export async function canCreateTask(): Promise<{ allowed: boolean; count: number
 
 /**
  * Check if the user can create a habit.
- * Free users: 3 active habits total. Premium users: unlimited.
+ * Free users: 5 active habits total. Premium users: unlimited.
  */
 export async function canCreateHabit(): Promise<{ allowed: boolean; count: number; limit: number }> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 
-  if (!user) return { allowed: false, count: 0, limit: 3 }
+  if (!user) return { allowed: false, count: 0, limit: 5 }
 
   if (await isCurrentUserPremium()) return { allowed: true, count: 0, limit: Infinity }
 
@@ -82,7 +82,7 @@ export async function canCreateHabit(): Promise<{ allowed: boolean; count: numbe
     .eq('is_active', true)
 
   const currentCount = count ?? 0
-  return { allowed: currentCount < 3, count: currentCount, limit: 3 }
+  return { allowed: currentCount < 5, count: currentCount, limit: 5 }
 }
 
 /**

--- a/app/api/payments/create-subscription/route.ts
+++ b/app/api/payments/create-subscription/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: Request) {
 
     // Get app URL for redirect
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-    const returnUrl = `${appUrl}/settings/subscription`;
+    const returnUrl = `${appUrl}/welcome-premium`;
     const dodopayments = getDodoClient();
 
     const session = await dodopayments.checkoutSessions.create({

--- a/components/dashboard/index.ts
+++ b/components/dashboard/index.ts
@@ -17,6 +17,7 @@ export { ProductivitySummary } from "./productivity-summary"
 export { MoodChart } from "./mood-chart"
 export { SentimentChart } from "./sentiment-chart"
 export { WeeklyWidget } from "./weekly-widget"
+export { PremiumUpsellBanner } from "./premium-upsell-banner"
 
 export {
   DashboardStatsSkeleton,

--- a/components/dashboard/premium-upsell-banner.tsx
+++ b/components/dashboard/premium-upsell-banner.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Sparkles, X } from "lucide-react"
+
+export function PremiumUpsellBanner() {
+  const [dismissed, setDismissed] = useState(true)
+
+  useEffect(() => {
+    const isDismissed = localStorage.getItem("rhythme_premium_upsell_dismissed") === "true"
+    setDismissed(isDismissed)
+  }, [])
+
+  const handleDismiss = () => {
+    localStorage.setItem("rhythme_premium_upsell_dismissed", "true")
+    setDismissed(true)
+  }
+
+  if (dismissed) return null
+
+  return (
+    <div className="bg-primary/[0.03] border border-primary/10 rounded-xl p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-left relative pr-10 sm:pr-12 shadow-sm">
+      <div className="flex gap-2.5 items-start">
+        <Sparkles className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            Identify patterns that derail your momentum
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+            Premium unlocks weekly reviews, advanced behavioral analytics, and unlimited goal tracking.
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Link href="/settings/subscription">
+          <Button size="sm" variant="outline" className="h-9 border-primary/20 hover:bg-primary/5 hover:text-primary transition-all text-xs font-medium bg-background/50">
+            Go Premium
+          </Button>
+        </Link>
+      </div>
+      <button
+        onClick={handleDismiss}
+        className="absolute top-3 right-3 p-1 rounded-full hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+        aria-label="Dismiss upsell"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/components/landing/pricing.tsx
+++ b/components/landing/pricing.tsx
@@ -42,11 +42,11 @@ interface Pricing {
 const pricing: Pricing = {
   monthly: {
     starter: 0,
-    premium: 12.99
+    premium: 9.99
   },
   yearly: {
     starter: 0,
-    premium: 79.99
+    premium: 99.99
   }
 };
 
@@ -61,7 +61,7 @@ interface PremiumFeature {
 // Starter plan features
 const starterFeatures = [
   { text: "1 Goal workspace", icon: Target, description: "Focus on one long-term goal at a time" },
-  { text: "Track up to 3 habits", icon: Flame, description: "Build your core daily habits" },
+  { text: "Track up to 5 habits", icon: Flame, description: "Build your core daily habits" },
   { text: "10 tasks per day", icon: Check, description: "Manage your daily priorities" },
   { text: "10 journal entries/month", icon: BookOpen, description: "Reflect on your journey" },
   { text: "Basic NBA suggestions", icon: Compass, description: "Simple next best action hints" },
@@ -157,10 +157,10 @@ export default function PricingComponent() {
             Simple Pricing
           </span>
           <h2 className="text-4xl md:text-5xl font-bold mb-4 font-primary">
-            Choose Your Path
+            One plan. Full depth.
           </h2>
           <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-            Start free. Upgrade when you&apos;re ready for <span className="text-primary font-semibold">AI-powered clarity</span>.
+            Start free. Go deeper when you&apos;re ready.
           </p>
         </motion.div>
 
@@ -225,7 +225,7 @@ export default function PricingComponent() {
                 <span className="text-5xl font-bold">$0</span>
                 <span className="text-muted-foreground">/forever</span>
               </div>
-              <p className="text-muted-foreground">Perfect for getting started</p>
+              <p className="text-muted-foreground">Everything you need to begin.</p>
             </div>
             <div className="p-8 text-left">
               <div className="space-y-4 mb-8">
@@ -258,16 +258,10 @@ export default function PricingComponent() {
             viewport={{ once: true }}
             className="relative glass-card rounded-2xl overflow-hidden border-primary/50 shadow-2xl shadow-primary/10 transition-all duration-500 ease-out hover:scale-[1.02]"
           >
-            {/* Recommended badge */}
-            <div className="absolute -top-0 left-1/2 transform -translate-x-1/2 translate-y-3 z-10">
-              <span className="bg-gradient-to-r from-primary to-accent text-primary-foreground px-4 py-1 rounded-full text-sm font-semibold shadow-lg">
-                <Crown className="w-4 h-4 inline mr-1" />
-                RECOMMENDED
-              </span>
-            </div>
+
             <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-accent/5 pointer-events-none"></div>
             
-            <div className="p-8 border-b border-border/50 pt-12">
+            <div className="p-8 border-b border-border/50 pt-8">
               <h3 className="text-2xl font-bold font-primary mb-2 flex items-center gap-2">
                 Premium <Sparkles className="w-5 h-5 text-accent" />
               </h3>
@@ -282,7 +276,7 @@ export default function PricingComponent() {
                   ${(yearlyPrice / 12).toFixed(2)}/month billed yearly
                 </p>
               )}
-              <p className="text-muted-foreground mt-2">Full power, AI-enhanced productivity</p>
+              <p className="text-muted-foreground mt-2">The complete system for builders who ship.</p>
             </div>
             
             <div className="p-8 text-left relative">
@@ -339,7 +333,7 @@ export default function PricingComponent() {
               <Link href="/signup/intro" className="block mt-6">
                 <button className="w-full px-6 py-3 rounded-xl font-semibold bg-gradient-to-r from-primary to-accent text-primary-foreground shadow-lg shadow-primary/25 hover:shadow-xl hover:shadow-primary/30 transition-all duration-500 ease-out">
                   <Sparkles className="w-4 h-4 inline mr-2" />
-                  Upgrade to Premium
+                  Go Premium
                 </button>
               </Link>
             </div>
@@ -355,11 +349,11 @@ export default function PricingComponent() {
           className="mt-16 space-y-4"
         >
           <p className="text-3xl md:text-4xl font-bold font-primary">
-            <span className="text-foreground">Start free, </span>
-            <span className="text-gradient-primary">grow with clarity</span>
+            <span className="text-foreground">Start free.</span>{" "}
+            <span className="text-gradient-primary">Go deeper when you&apos;re ready.</span>
           </p>
           <p className="text-muted-foreground text-lg">
-            No credit card required • Cancel anytime • 30-day money-back guarantee
+            No credit card required • Cancel anytime
           </p>
         </motion.div>
       </div>

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -22,6 +22,7 @@ import {
   User,
   Goal,
   EllipsisVertical,
+  ArrowRight,
 } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -201,7 +202,7 @@ export function NavUser({
               </DropdownMenuItem>
               <DropdownMenuItem 
                 className="flex items-center gap-2 rounded-lg px-2 py-2 text-muted-foreground cursor-pointer"
-                onClick={() => handleNavigation("/settings/billing")}
+                onClick={() => handleNavigation("/settings/subscription")}
               >
                 <span className="flex h-6 w-6 items-center justify-center rounded-md border border-dashed border-muted-foreground/50">
                   <Plus className="h-3 w-3" />
@@ -229,10 +230,8 @@ export function NavUser({
                 onClick={() => handleNavigation("/settings/subscription")}
               >
                 <Sparkles className="h-4 w-4 text-primary" />
-                <span className="flex-1 text-sm font-medium">Upgrade to Pro</span>
-                <Badge variant="secondary" className="bg-primary text-primary-foreground text-[10px] px-1.5 py-0">
-                  NEW
-                </Badge>
+                <span className="flex-1 text-sm font-medium">Go Premium</span>
+                <ArrowRight className="h-3.5 w-3.5 text-primary" />
               </DropdownMenuItem>
             )}
 

--- a/components/premium-gate-modal.tsx
+++ b/components/premium-gate-modal.tsx
@@ -9,46 +9,34 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
-import { Crown, Sparkles, Lock, Zap } from "lucide-react"
+import { Sparkles, Lock, Zap } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { motion } from "framer-motion"
 
 export type PremiumGateReason = "journal" | "task" | "habit" | "mood" | "weekly"
 
 const GATE_CONFIG: Record<PremiumGateReason, {
-  title: string
   description: string
-  limit: string
   icon: React.ElementType
 }> = {
   journal: {
-    title: "Journal Limit Reached",
-    description: "Free users can create 1 journal entry per day.",
-    limit: "1 journal/day",
+    description: "Your reflections deserve space. Premium gives you unlimited entries to capture every insight.",
     icon: Lock,
   },
   task: {
-    title: "Task Limit Reached",
-    description: "Free users can create up to 10 tasks per day.",
-    limit: "10 tasks/day",
+    description: "Big days need room to breathe. Premium means no cap on what you can plan.",
     icon: Zap,
   },
   habit: {
-    title: "Habit Limit Reached",
-    description: "Free users can track up to 3 habits.",
-    limit: "3 habits total",
+    description: "You're building real momentum. Premium removes the ceiling — track every habit that matters to you.",
     icon: Sparkles,
   },
   mood: {
-    title: "Mood Log Limit Reached",
-    description: "Free users can save 1 mood log per day.",
-    limit: "1 mood log/day",
+    description: "Consistent tracking reveals the deepest patterns. Premium unlocks unlimited mood logging.",
     icon: Lock,
   },
   weekly: {
-    title: "Weekly Review Locked",
-    description: "Free users can plan their week. Reviews and AI insights require Premium.",
-    limit: "Planning only",
+    description: "Weekly reviews are where patterns become clarity. This is a Premium capability.",
     icon: Sparkles,
   },
 }
@@ -66,78 +54,45 @@ export function PremiumGateModal({ open, onOpenChange, reason }: PremiumGateModa
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[420px]">
+      <DialogContent className="sm:max-w-[380px]">
         <DialogHeader className="space-y-4">
-          {/* Icon with glow */}
           <motion.div
             initial={{ scale: 0.8, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ type: "spring", stiffness: 400, damping: 25 }}
-            className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 border border-primary/20"
+            className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 border border-primary/20"
           >
-            <Icon className="h-8 w-8 text-primary" />
+            <Icon className="h-7 w-7 text-primary" />
           </motion.div>
 
-          <DialogTitle className="text-center text-xl font-semibold">
-            {config.title}
+          <DialogTitle className="text-center text-lg font-semibold">
+            You&apos;re ready for more.
           </DialogTitle>
-          <DialogDescription className="text-center text-sm">
+          <DialogDescription className="text-center text-sm leading-relaxed">
             {config.description}
           </DialogDescription>
         </DialogHeader>
 
-        {/* Limit indicator */}
-        <div className="my-4 p-4 rounded-xl bg-muted/50 border border-border/50">
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">Free plan limit</span>
-            <span className="text-sm font-semibold text-foreground">{config.limit}</span>
-          </div>
-          <div className="mt-3 h-2 rounded-full bg-muted overflow-hidden">
-            <motion.div
-              initial={{ width: 0 }}
-              animate={{ width: "100%" }}
-              transition={{ duration: 0.6, ease: "easeOut" }}
-              className="h-full rounded-full bg-primary"
-            />
-          </div>
-          <p className="mt-2 text-xs text-muted-foreground text-center">
-            You've reached the free plan limit
-          </p>
-        </div>
-
-        {/* Premium perks */}
-        <div className="space-y-2">
-          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-            With Premium you get
-          </p>
-          <div className="grid gap-1.5">
-            {["Unlimited journals every day", "Unlimited tasks", "Unlimited mood logs", "Custom themes & more"].map((perk) => (
-              <div key={perk} className="flex items-center gap-2 text-sm">
-                <Crown className="h-3.5 w-3.5 text-primary shrink-0" />
-                <span className="text-muted-foreground">{perk}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-
         <DialogFooter className="mt-4 flex flex-col gap-2 sm:flex-col">
           <Button
-            className="w-full gap-2 bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20"
+            className="w-full gap-2 bg-primary text-primary-foreground hover:bg-primary/90"
             onClick={() => {
               onOpenChange(false)
               router.push("/settings/subscription")
             }}
           >
-            <Crown className="h-4 w-4" />
-            Upgrade to Premium
+            Go Premium
           </Button>
           <Button
             variant="ghost"
             className="w-full text-muted-foreground"
             onClick={() => onOpenChange(false)}
           >
-            Maybe later
+            Not yet
           </Button>
+          <p className="text-[11px] text-muted-foreground/60 text-center mt-1">
+            Cancel anytime
+          </p>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/docs/project-report.md
+++ b/docs/project-report.md
@@ -1,0 +1,340 @@
+# Rhythme Project Report
+
+**Project:** Rhythme  
+**Version in codebase:** `0.67.0`  
+**Type:** Web-based productivity and emotional-awareness platform  
+**Current repo status reviewed:** May 30, 2026
+
+## 1. What the product is
+
+Rhythme is a premium productivity system that combines execution tools and self-awareness tools in one app. Its core promise is to help users stay consistent without overwhelm by unifying tasks, habits, journaling, mood tracking, focus sessions, weekly planning, and light AI-assisted workflows inside one calmer workspace.
+
+The product is positioned less like a generic task manager and more like a personal operating system. The idea repeated across the PRD, onboarding docs, landing content, and app structure is:
+
+- reduce decision fatigue
+- connect productivity with emotion and reflection
+- keep the experience premium, minimal, and privacy-conscious
+- build toward future AI guidance without making MVP feel like an experimental AI toy
+
+## 2. Product thesis
+
+Rhythme is built around a simple problem: most productivity tools track activity but do not answer, in a grounded way, what matters now or how the user is actually doing. This product tries to close that gap by combining:
+
+- execution: tasks, habits, focus
+- awareness: journaling, mood, reflection
+- rhythm: weekly planning and review
+- direction: onboarding tied to one primary goal/workspace
+- monetization: premium gates around higher-value insights, customization, and advanced usage
+
+## 3. Target users
+
+Primary audience described in product docs:
+
+- students
+- young professionals
+- freelancers
+- solo builders / ambitious individual users
+
+Common user traits:
+
+- ambitious but inconsistent
+- affected by stress, burnout, and motivation swings
+- wants structure without tool sprawl
+- values clarity, clean design, and privacy
+
+## 4. Core product principles
+
+The strongest recurring product rules are:
+
+- clarity over feature overload
+- emotion-aware, not emotion-heavy
+- minimal setup with immediate value
+- privacy-first by design
+- premium feel over experimental feel
+
+## 5. What exists in the app today
+
+The repo shows a broad working surface area, not just a concept site.
+
+### Public/marketing surface
+
+- landing page
+- features page
+- pricing page
+- about page
+- beta page
+- legal pages for privacy, terms, cookie policy
+
+### Authentication and account
+
+- login
+- signup intro and account creation flow
+- auth callback and reset-password flow
+- logout page
+- account update-password page
+- secure auth via Supabase
+
+### Main app areas
+
+- dashboard
+- tasks
+- habits
+- journal
+- journal insights
+- mood
+- activity
+- focus
+- focus history
+- weekly
+- goals
+- AI page
+- full settings area with many subsections
+
+### Settings surface
+
+- account
+- profile
+- appearance
+- theme
+- custom themes
+- notifications
+- privacy
+- security
+- connections
+- onboarding
+- billing
+- billing history
+- subscription
+- delete account
+
+## 6. Functional modules
+
+### Dashboard
+
+The dashboard acts as the command center. Current code and changelog indicate it includes:
+
+- today-oriented overview
+- quick actions
+- task and habit summaries
+- mood and journal widgets
+- productivity charts
+- weekly widget
+- activity feed
+- reflection prompts
+- greeting/personalization
+- right sidebar calendar and activity inspector
+
+### Tasks
+
+Task management is a core execution layer with dedicated pages and detail views. Current architecture suggests support for:
+
+- task creation, editing, completion, deletion
+- slugs/detail pages
+- filtering/sorting
+- due dates and organization metadata
+- dashboard/task integration
+- premium/free usage-limit checks
+
+### Habits
+
+Habits are one of the most developed systems in the repo. Current implementation includes:
+
+- habit creation and editing
+- active/inactive habit handling
+- unified frequency model using `frequency_num`, `target_count`, and `period`
+- period-based completions instead of older daily/weekly split
+- streak logic
+- habit detail pages
+- heatmap visualization
+- daily activity inspector integration
+- optimistic UI updates
+- rule-based prediction/risk-oriented utilities
+- free-tier active habit limits
+
+### Journaling
+
+Journaling is both a reflection feature and a data source for insight features. Current codebase includes:
+
+- journal list page
+- new journal flow
+- journal detail page
+- journal insights page
+- sentiment-related utilities
+- storage helpers
+- encryption-related logic and passphrase flows
+- journal usage-limit checks for free users
+
+### Mood tracking
+
+Mood is treated as lightweight emotional logging, not therapy tooling. Current implementation includes:
+
+- mood logging
+- mood history page
+- mood selector components
+- mood charts/sparklines
+- weekly mood correlation inputs
+- free-tier daily limit checks
+
+### Focus mode
+
+Focus mode supports deep work and timing workflows. Current implementation includes:
+
+- focus page
+- active timer
+- session detail page
+- focus history
+- focus audio helper
+- focus storage utilities
+- floating focus widget
+- session completion UI
+- optional linkage to broader productivity context
+
+### Weekly system
+
+Weekly planning/review is already represented in both docs and shipped route structure. Current signals indicate:
+
+- weekly page
+- weekly plan/review/history logic in actions
+- weekly widget on dashboard
+- review carousel UI
+- mood sparkline
+- correlation cards
+- habit/mood/task summary logic
+- calm reflective workflow rather than dense analytics
+
+### Notifications
+
+The app includes a notification system with:
+
+- notification popover
+- unread badge
+- polling
+- mark-one and mark-all-as-read flows
+- browser notification prompt components
+- push subscription endpoints
+
+### Premium and billing
+
+Premium is not just planned; it is actively wired into the app:
+
+- subscription status server actions
+- Dodo Payments checkout creation
+- webhook handling
+- billing and subscription settings pages
+- entitlement checks
+- feature/usage gating
+- premium gate modal
+
+### AI and ML direction
+
+AI exists in two different states:
+
+- practical backend hooks already present:
+  - AI health endpoint
+  - onboarding generation endpoint
+  - sentiment and habit-prediction utilities
+  - ML warm-service hooks
+- future-facing product layer still partly aspirational:
+  - AI agent page
+  - Next Best Action Engine concepts
+  - roadmap/agent mock interactions
+
+Important distinction: the dedicated AI page currently reads like an in-development showcase rather than a fully production-backed agent workflow.
+
+## 7. Onboarding and workspace model
+
+One of the most important product decisions in the repo is the move toward a **single primary goal workspace**.
+
+Onboarding docs define this model clearly:
+
+- user enters one main goal
+- that goal becomes the workspace anchor
+- generated starter tasks and habits orbit that goal
+- tasks can act as practical sub-goals
+- commitment screen frames the shift from setup to action
+
+This is a key product identity choice because it makes Rhythme feel more directional than a normal planner.
+
+## 8. Business model
+
+Rhythme is designed as a freemium subscription product.
+
+Product docs and code together show:
+
+- free tier with usage caps
+- premium tier for unlimited or expanded use
+- billing via Dodo Payments
+- monthly and yearly plan support
+- premium-gated AI/insight/customization-style value
+
+Current code-level limit examples:
+
+- journals: 1 per day for free users
+- tasks: 10 per day for free users
+- habits: 3 active habits for free users
+- mood logs: 1 per day for free users
+
+This is important because the current implementation is stricter than some older PRD examples, so the product has clearly evolved.
+
+## 9. Technical architecture
+
+### Frontend
+
+- Next.js App Router
+- React 19
+- TypeScript
+- Tailwind CSS v4
+- shadcn/ui and Radix-based UI primitives
+- Framer Motion for richer UI motion
+- TanStack Query and Zustand for client state/data flows
+
+### Backend and data
+
+- Supabase Auth
+- Supabase/PostgreSQL
+- row-level security patterns
+- server actions for core app workflows
+- Supabase migrations for evolving product schema
+
+### Payments and delivery
+
+- Dodo Payments
+- Vercel Analytics
+- Vercel-style deployment assumptions
+
+### PWA and device behavior
+
+- web app manifest
+- service worker registration
+- offline indicator
+- install prompt support
+- Apple splash screens
+- standalone app configuration
+
+## 10. Privacy and security posture
+
+Privacy is a visible part of the product positioning and implementation. Evidence in the repo includes:
+
+- journal encryption flows and passphrase handling
+- metadata-first sentiment handling direction in docs
+- secure auth flows
+- account deletion flows with explicit server-side cleanup
+- privacy/legal sections
+- row-level access control patterns via Supabase
+
+## 11. Product maturity summary
+
+Rhythme is beyond the idea stage. It is already a substantial product with:
+
+- a real authenticated application
+- multiple connected productivity modules
+- a premium subscription layer
+- PWA support
+- weekly systems and notifications
+- active schema evolution and documented release history
+
+At the same time, some of the most differentiated “intelligence” positioning is still emerging rather than fully shipped. The strongest current value is the integrated productivity + reflection stack, while the strongest future value is the AI-guided, goal-centered workspace model.
+
+## 12. Concise definition
+
+Rhythme is a premium web productivity OS for individuals that combines tasks, habits, journaling, mood, focus, and weekly reflection into one privacy-conscious workspace, with monetized premium features and an in-progress path toward AI-guided goal execution.


### PR DESCRIPTION
Adds a full-featured premium paywall and onboarding flow, updates pricing/copy, and raises the free habit limit. Key changes:

- New welcome page for post-checkout (/welcome-premium) and create-subscription now redirects to it.
- Major SubscriptionSection rewrite: interactive full-screen paywall, checkout steps, animations, and improved UX for starter/premium flows.
- New PremiumUpsellBanner component and export; dashboard shows upsell for free users.
- Pricing updates across UI: monthly/yearly price adjustments and copy refinements on landing/pricing and billing settings.
- Free-tier habit limit increased from 3 to 5: updated canCreateHabit and related UI text/features.
- PremiumGateModal copy/UI simplified and CTA adjusted.
- Small nav and menu label changes (Go Premium) and various UX copy tweaks.
- Adds project report docs (docs/project-report.md).

These changes aim to improve upgrade conversion, clarify plan benefits, and align client-side limits and messaging with the new pricing/plan structure.