### PR TITLE
Add account deletion flow and auth helpers

### DIFF
--- a/app/(app)/settings/delete-account/_components/delete-account-section.tsx
+++ b/app/(app)/settings/delete-account/_components/delete-account-section.tsx
@@ -4,7 +4,7 @@
 "use client"
 
 import { AlertTriangle, Trash2, Info } from "lucide-react"
-import { DeleteAccountModal } from "@/components/settings/delete-account-modal"
+import { AccountDeletionModal } from "@/components/settings/AccountDeletionModal"
 
 interface DeleteAccountSectionProps {
   userEmail: string
@@ -76,7 +76,7 @@ export function DeleteAccountSection({ userEmail }: DeleteAccountSectionProps) {
               Permanently remove your account and all data
             </p>
           </div>
-          <DeleteAccountModal />
+          <AccountDeletionModal />
         </div>
       </section>
     </div>

--- a/app/(app)/settings/profile/_components/profile-section.tsx
+++ b/app/(app)/settings/profile/_components/profile-section.tsx
@@ -14,7 +14,10 @@ import {
   Calendar,
   CheckCircle2,
   Loader2,
+  AlertTriangle,
 } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { AccountDeletionModal } from "@/components/settings/AccountDeletionModal"
 
 interface ProfileSectionProps {
   user: {
@@ -132,6 +135,27 @@ export function ProfileSection({ user }: ProfileSectionProps) {
           )}
         </Button>
       </form>
+
+      {/* Danger Zone */}
+      <div className="border-b border-border/50 my-6" />
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold flex items-center gap-2 text-destructive">
+          <AlertTriangle className="h-5 w-5" />
+          Danger Zone
+        </h3>
+        <Card className="border-destructive/20 bg-destructive/5 overflow-hidden">
+          <CardContent className="p-4 flex items-center justify-between sm:flex-row flex-col gap-4">
+            <div className="space-y-1">
+              <p className="font-semibold text-destructive">Delete Account</p>
+              <p className="text-xs text-muted-foreground max-w-md leading-relaxed">
+                Permanently remove your personal data, habits, daily logs, focus history, journals, and subscription. 
+                This action is irreversible.
+              </p>
+            </div>
+            <AccountDeletionModal />
+          </CardContent>
+        </Card>
+      </div>
     </div>
   )
 }

--- a/app/(app)/settings/security/_components/security-section.tsx
+++ b/app/(app)/settings/security/_components/security-section.tsx
@@ -13,7 +13,7 @@ import {
 import { toast } from "sonner"
 import { SessionInfo } from "@/components/settings/session-info"
 import { ChangePassphraseSection } from "./change-passphrase-section"
-import { updatePassword } from "@/app/actions/auth"
+import { changePasswordWithVerification, checkUserAuthType } from "@/app/actions/auth"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -25,15 +25,36 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 
 export default function SecuritySection({ userId }: { userId: string }) {
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
+  const [oldPassword, setOldPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [isUpdatingPassword, setIsUpdatingPassword] = useState(false)
 
+  const [hasPassword, setHasPassword] = useState(true)
+  const [isLoadingAuth, setIsLoadingAuth] = useState(true)
+
+  useEffect(() => {
+    if (isPasswordModalOpen) {
+      checkUserAuthType()
+        .then((res) => {
+          setHasPassword(res.hasPassword)
+        })
+        .finally(() => {
+          setIsLoadingAuth(false)
+        })
+    }
+  }, [isPasswordModalOpen])
+
   const handlePasswordUpdate = async () => {
+    if (hasPassword && !oldPassword) {
+      toast.error("Current password is required")
+      return
+    }
+
     if (newPassword !== confirmPassword) {
       toast.error("Passwords do not match")
       return
@@ -45,14 +66,16 @@ export default function SecuritySection({ userId }: { userId: string }) {
     }
 
     setIsUpdatingPassword(true)
-    const result = await updatePassword(newPassword)
+    const result = await changePasswordWithVerification(oldPassword, newPassword)
     setIsUpdatingPassword(false)
 
     if (result.success) {
       toast.success("Password updated successfully")
       setIsPasswordModalOpen(false)
+      setOldPassword("")
       setNewPassword("")
       setConfirmPassword("")
+      setHasPassword(true)
     } else {
       toast.error(result.error || "Failed to update password")
     }
@@ -81,7 +104,14 @@ export default function SecuritySection({ userId }: { userId: string }) {
             </p>
           </div>
           
-          <Dialog open={isPasswordModalOpen} onOpenChange={setIsPasswordModalOpen}>
+          <Dialog open={isPasswordModalOpen} onOpenChange={(open) => { 
+            setIsPasswordModalOpen(open); 
+            if (!open) { 
+              setOldPassword(""); 
+              setNewPassword(""); 
+              setConfirmPassword(""); 
+            } 
+          }}>
             <DialogTrigger asChild>
               <Button variant="outline" size="sm">
                 Update
@@ -95,24 +125,46 @@ export default function SecuritySection({ userId }: { userId: string }) {
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4 py-2">
-                <div className="space-y-2">
-                  <Label htmlFor="new-password">New Password</Label>
-                  <Input 
-                    id="new-password" 
-                    type="password" 
-                    value={newPassword}
-                    onChange={(e) => setNewPassword(e.target.value)}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="confirm-password">Confirm Password</Label>
-                  <Input 
-                    id="confirm-password" 
-                    type="password" 
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                  />
-                </div>
+                {isLoadingAuth ? (
+                  <div className="flex items-center justify-center py-4">
+                    <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                  </div>
+                ) : (
+                  <>
+                    {hasPassword && (
+                      <div className="space-y-2">
+                        <Label htmlFor="old-password">Current Password</Label>
+                        <Input 
+                          id="old-password" 
+                          type="password" 
+                          value={oldPassword}
+                          onChange={(e) => setOldPassword(e.target.value)}
+                          placeholder="Enter current password"
+                        />
+                      </div>
+                    )}
+                    <div className="space-y-2">
+                      <Label htmlFor="new-password">New Password</Label>
+                      <Input 
+                        id="new-password" 
+                        type="password" 
+                        value={newPassword}
+                        onChange={(e) => setNewPassword(e.target.value)}
+                        placeholder="At least 6 characters"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="confirm-password">Confirm New Password</Label>
+                      <Input 
+                        id="confirm-password" 
+                        type="password" 
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        placeholder="Repeat new password"
+                      />
+                    </div>
+                  </>
+                )}
               </div>
               <DialogFooter>
                 <Button variant="ghost" onClick={() => setIsPasswordModalOpen(false)}>Cancel</Button>

--- a/app/(app)/settings/security/security-settings-content.tsx
+++ b/app/(app)/settings/security/security-settings-content.tsx
@@ -18,7 +18,7 @@ import {
 import { toast } from "sonner"
 import { SessionInfo } from "@/components/settings/session-info"
 import { ChangePassphraseSection } from "./_components/change-passphrase-section"
-import { updatePassword } from "@/app/actions/auth"
+import { changePasswordWithVerification, checkUserAuthType } from "@/app/actions/auth"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -30,15 +30,36 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 
 export default function SecuritySettingsContent({ userId }: { userId: string }) {
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
+  const [oldPassword, setOldPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [isUpdatingPassword, setIsUpdatingPassword] = useState(false)
+  
+  const [hasPassword, setHasPassword] = useState(true)
+  const [isLoadingAuth, setIsLoadingAuth] = useState(true)
+
+  useEffect(() => {
+    if (isPasswordModalOpen) {
+      checkUserAuthType()
+        .then((res) => {
+          setHasPassword(res.hasPassword)
+        })
+        .finally(() => {
+          setIsLoadingAuth(false)
+        })
+    }
+  }, [isPasswordModalOpen])
 
   const handlePasswordUpdate = async () => {
+    if (hasPassword && !oldPassword) {
+      toast.error("Current password is required")
+      return
+    }
+
     if (newPassword !== confirmPassword) {
       toast.error("Passwords do not match")
       return
@@ -50,14 +71,16 @@ export default function SecuritySettingsContent({ userId }: { userId: string }) 
     }
 
     setIsUpdatingPassword(true)
-    const result = await updatePassword(newPassword)
+    const result = await changePasswordWithVerification(oldPassword, newPassword)
     setIsUpdatingPassword(false)
 
     if (result.success) {
       toast.success("Password updated successfully")
       setIsPasswordModalOpen(false)
+      setOldPassword("")
       setNewPassword("")
       setConfirmPassword("")
+      setHasPassword(true)
     } else {
       toast.error(result.error || "Failed to update password")
     }
@@ -97,7 +120,14 @@ export default function SecuritySettingsContent({ userId }: { userId: string }) 
               </p>
             </div>
             
-            <Dialog open={isPasswordModalOpen} onOpenChange={setIsPasswordModalOpen}>
+            <Dialog open={isPasswordModalOpen} onOpenChange={(open) => { 
+              setIsPasswordModalOpen(open); 
+              if (!open) { 
+                setOldPassword(""); 
+                setNewPassword(""); 
+                setConfirmPassword(""); 
+              } 
+            }}>
               <DialogTrigger asChild>
                 <Button variant="outline" size="sm">
                   Update
@@ -111,24 +141,46 @@ export default function SecuritySettingsContent({ userId }: { userId: string }) 
                   </DialogDescription>
                 </DialogHeader>
                 <div className="space-y-4 py-2">
-                  <div className="space-y-2">
-                    <Label htmlFor="new-password">New Password</Label>
-                    <Input 
-                      id="new-password" 
-                      type="password" 
-                      value={newPassword}
-                      onChange={(e) => setNewPassword(e.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="confirm-password">Confirm Password</Label>
-                    <Input 
-                      id="confirm-password" 
-                      type="password" 
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                    />
-                  </div>
+                  {isLoadingAuth ? (
+                    <div className="flex items-center justify-center py-4">
+                      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                    </div>
+                  ) : (
+                    <>
+                      {hasPassword && (
+                        <div className="space-y-2">
+                          <Label htmlFor="old-password">Current Password</Label>
+                          <Input 
+                            id="old-password" 
+                            type="password" 
+                            value={oldPassword}
+                            onChange={(e) => setOldPassword(e.target.value)}
+                            placeholder="Enter current password"
+                          />
+                        </div>
+                      )}
+                      <div className="space-y-2">
+                        <Label htmlFor="new-password">New Password</Label>
+                        <Input 
+                          id="new-password" 
+                          type="password" 
+                          value={newPassword}
+                          onChange={(e) => setNewPassword(e.target.value)}
+                          placeholder="At least 6 characters"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="confirm-password">Confirm New Password</Label>
+                        <Input 
+                          id="confirm-password" 
+                          type="password" 
+                          value={confirmPassword}
+                          onChange={(e) => setConfirmPassword(e.target.value)}
+                          placeholder="Repeat new password"
+                        />
+                      </div>
+                    </>
+                  )}
                 </div>
                 <DialogFooter>
                   <Button variant="ghost" onClick={() => setIsPasswordModalOpen(false)}>Cancel</Button>

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -3,6 +3,7 @@
 
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 import { revalidatePath } from 'next/cache'
 import { headers } from 'next/headers'
 
@@ -304,4 +305,199 @@ export async function sendPasswordResetEmail(email: string): Promise<{ success: 
   }
 
   return { success: true }
+}
+
+/**
+ * Verifies if the current logged-in user password is correct
+ */
+export async function verifyCurrentPassword(password: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+
+    if (userError || !user) {
+      return { success: false, error: "Not authenticated" }
+    }
+
+    if (!user.email) {
+      return { success: false, error: "User email not found" }
+    }
+
+    // Create standalone client without writing local session/cookies
+    const tempClient = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+      {
+        auth: {
+          persistSession: false,
+          autoRefreshToken: false,
+        }
+      }
+    )
+
+    const { error: authError } = await tempClient.auth.signInWithPassword({
+      email: user.email,
+      password: password,
+    })
+
+    if (authError) {
+      return { success: false, error: "Incorrect password" }
+    }
+
+    return { success: true }
+  } catch (err) {
+    console.error("Password verification error:", err)
+    return { success: false, error: "Failed to verify password" }
+  }
+}
+
+/**
+ * Checks the authentication providers for the current user
+ */
+export async function checkUserAuthType(): Promise<{ hasPassword: boolean; provider: string }> {
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+
+    if (!user) {
+      return { hasPassword: false, provider: "" }
+    }
+
+    // Direct database check on auth.users using Security Definer RPC
+    const { data: dbHasPassword, error: rpcError } = await supabase.rpc("user_has_password", {
+      target_user_id: user.id
+    })
+
+    let hasPassword = false
+    if (rpcError) {
+      console.warn("[WARNING] user_has_password RPC failed, falling back to providers list metadata:", rpcError)
+      hasPassword = (user.app_metadata?.providers || []).includes("email")
+    } else {
+      hasPassword = !!dbHasPassword
+    }
+
+    const providers = user.app_metadata?.providers || []
+    return {
+      hasPassword,
+      provider: providers[0] || "oauth",
+    }
+  } catch (err) {
+    console.error("Auth type check error:", err)
+    return { hasPassword: true, provider: "email" } // Default to email/password on error to be safe
+  }
+}
+
+/**
+ * Sets the initial password for a social login (OAuth) user who doesn't have a password.
+ * Strictly guarded to prevent users with existing passwords from abusing it.
+ */
+export async function setInitialSocialPassword(password: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+
+    if (userError || !user) {
+      return { success: false, error: "Not authenticated" }
+    }
+
+    // Direct database check on auth.users using Security Definer RPC
+    const { data: dbHasPassword, error: rpcError } = await supabase.rpc("user_has_password", {
+      target_user_id: user.id
+    })
+
+    let hasPassword = false
+    if (rpcError) {
+      console.warn("[WARNING] user_has_password RPC failed, falling back to providers list metadata:", rpcError)
+      hasPassword = (user.app_metadata?.providers || []).includes("email")
+    } else {
+      hasPassword = !!dbHasPassword
+    }
+
+    if (hasPassword) {
+      return { success: false, error: "Account already has a password set. Bypassing is prohibited." }
+    }
+
+    const { error } = await supabase.auth.updateUser({
+      password: password
+    })
+
+    if (error) {
+      return { success: false, error: error.message }
+    }
+
+    return { success: true }
+  } catch (err) {
+    console.error("Failed to set social password:", err)
+    return { success: false, error: "Failed to configure password" }
+  }
+}
+
+/**
+ * Changes user password after verifying the old password.
+ */
+export async function changePasswordWithVerification(
+  oldPassword: string,
+  newPassword: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+
+    if (userError || !user) {
+      return { success: false, error: "Not authenticated" }
+    }
+
+    if (!user.email) {
+      return { success: false, error: "User email not found" }
+    }
+
+    // Direct database check on auth.users using Security Definer RPC
+    const { data: dbHasPassword, error: rpcError } = await supabase.rpc("user_has_password", {
+      target_user_id: user.id
+    })
+
+    let hasPassword = false
+    if (rpcError) {
+      console.warn("[WARNING] user_has_password RPC failed, falling back to providers list metadata:", rpcError)
+      hasPassword = (user.app_metadata?.providers || []).includes("email")
+    } else {
+      hasPassword = !!dbHasPassword
+    }
+
+    if (hasPassword) {
+      const tempClient = createSupabaseClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+        {
+          auth: {
+            persistSession: false,
+            autoRefreshToken: false,
+          }
+        }
+      )
+
+      const { error: signInError } = await tempClient.auth.signInWithPassword({
+        email: user.email,
+        password: oldPassword,
+      })
+
+      if (signInError) {
+        return { success: false, error: "Incorrect current password" }
+      }
+    }
+
+    // 2. Perform the update
+    const { error: updateError } = await supabase.auth.updateUser({
+      password: newPassword,
+    })
+
+    if (updateError) {
+      return { success: false, error: updateError.message }
+    }
+
+    return { success: true }
+  } catch (err) {
+    console.error("Change password error:", err)
+    return { success: false, error: "Failed to change password" }
+  }
 }

--- a/app/api/v1/account/delete/route.ts
+++ b/app/api/v1/account/delete/route.ts
@@ -1,0 +1,159 @@
+// app/api/v1/account/delete/route.ts
+
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { getAdminClient } from "@/lib/supabase/admin"
+import { getDodoClient } from "@/lib/payments/dodo"
+import { createClient as createSupabaseClient } from "@supabase/supabase-js"
+
+export async function POST(request: Request) {
+  try {
+    // 1. Verify user session
+    const supabase = await createClient()
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+
+    if (userError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const userId = user.id
+    const userEmail = user.email
+
+    if (!userEmail) {
+      return NextResponse.json({ error: "User email not found" }, { status: 400 })
+    }
+
+    // 2. Parse request body
+    const body = await request.json().catch(() => ({}))
+    const { password } = body
+
+    // 3. Verify password (mandatory for all account deletions to prevent session hijacking)
+    if (!password) {
+      return NextResponse.json({ error: "Password is required to proceed" }, { status: 400 })
+    }
+
+    // Create standalone Supabase client to avoid side-effects on the current session/cookies
+    const tempClient = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+      {
+        auth: {
+          persistSession: false,
+          autoRefreshToken: false,
+        },
+      }
+    )
+
+    const { error: signInError } = await tempClient.auth.signInWithPassword({
+      email: userEmail,
+      password: password,
+    })
+
+    if (signInError) {
+      return NextResponse.json({ error: "Incorrect password" }, { status: 400 })
+    }
+
+    const supabaseAdmin = getAdminClient()
+
+    // 5. Cancel any active billing subscriptions first to prevent future charges
+    const { data: subscriptions, error: subError } = await supabaseAdmin
+      .from("account_subscriptions")
+      .select("id, provider_subscription_id, provider")
+      .eq("user_id", userId)
+      .eq("entitlement_active", true)
+
+    if (subError) {
+      console.error("Failed to query user subscriptions:", subError)
+    }
+
+    for (const sub of subscriptions || []) {
+      if (sub.provider === "dodo" && sub.provider_subscription_id) {
+        try {
+          console.log(`[INFO] Cancelling subscription: ${sub.provider_subscription_id}`)
+          await getDodoClient().subscriptions.update(sub.provider_subscription_id, {
+            cancel_at_next_billing_date: true,
+            cancel_reason: "cancelled_by_customer",
+          })
+
+          // Mark subscription as cancelled in local database
+          await supabaseAdmin
+            .from("account_subscriptions")
+            .update({
+              status: "cancelled",
+              entitlement_active: false,
+              updated_at: new Date().toISOString(),
+            })
+            .eq("id", sub.id)
+        } catch (subCancelErr) {
+          console.error(`[ERROR] Failed to cancel subscription ${sub.provider_subscription_id}:`, subCancelErr)
+          // Fail the account deletion if we can't guarantee subscription cancellation to avoid charging deleted accounts
+          return NextResponse.json({
+            error: "Failed to cancel your active billing subscription. Please try again or contact support."
+          }, { status: 500 })
+        }
+      }
+    }
+
+    // 6. Delete user data inside a transaction using the RPC function
+    const { error: rpcError } = await supabaseAdmin.rpc("delete_user_data", {
+      target_user_id: userId,
+    })
+
+    if (rpcError) {
+      console.warn("[WARNING] delete_user_data RPC failed or not found, falling back to sequential deletes:", rpcError)
+
+      // Fallback: Sequential deletion (in reverse order to respect potential FK constraints)
+      const tables = [
+        { name: "habit_logs", field: "user_id" },
+        { name: "daily_logs", field: "user_id" },
+        { name: "focus_sessions", field: "user_id" },
+        { name: "mood_logs", field: "user_id" },
+        { name: "journals", field: "user_id" },
+        { name: "tasks", field: "user_id" },
+        { name: "user_goals", field: "user_id" },
+        { name: "weekly_plan", field: "user_id" },
+        { name: "weekly_review", field: "user_id" },
+        { name: "notifications", field: "user_id" },
+        { name: "push_subscriptions", field: "user_id" },
+        { name: "user_preferences", field: "user_id" },
+        { name: "habits", field: "user_id" },
+        { name: "profiles", field: "id" },
+        { name: "account_subscriptions", field: "user_id" },
+        { name: "billing_events", field: "user_id" },
+      ]
+
+      for (const { name, field } of tables) {
+        const { error: deleteError } = await supabaseAdmin
+          .from(name)
+          .delete()
+          .eq(field, userId)
+
+        if (deleteError) {
+          console.error(`[ERROR] Fallback deletion failed for table ${name}:`, deleteError)
+        }
+      }
+    }
+
+    // 7. Delete the Supabase Auth user record using admin privileges
+    const { error: authDeleteError } = await supabaseAdmin.auth.admin.deleteUser(userId)
+
+    if (authDeleteError) {
+      console.error("[ERROR] Failed to delete Supabase auth user:", authDeleteError)
+      return NextResponse.json(
+        { error: "Failed to fully delete your account credential. Please contact support." },
+        { status: 500 }
+      )
+    }
+
+    // 8. Sign out from the current server session to clear cookies
+    await supabase.auth.signOut()
+
+    // 9. Log anonymized deletion event
+    console.log(`[SUCCESS] Account successfully deleted for anonymized user ID: ${userId}`)
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("[ERROR] Account deletion handler error:", error)
+    return NextResponse.json({ error: "An unexpected error occurred. Please try again." }, { status: 500 })
+  }
+}

--- a/components/settings/AccountDeletionModal.tsx
+++ b/components/settings/AccountDeletionModal.tsx
@@ -1,0 +1,455 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { verifyCurrentPassword, checkUserAuthType, setInitialSocialPassword } from "@/app/actions/auth"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
+import { AlertTriangle, Loader2, Trash2, KeyRound, ArrowRight, ShieldAlert, Key } from "lucide-react"
+import { toast } from "sonner"
+
+type AuthFlowState = "checking" | "set_password" | "verify_password" | "confirmation"
+
+export function AccountDeletionModal() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [flowState, setFlowState] = useState<AuthFlowState>("checking")
+  
+  // Account details
+  const [hasPassword, setHasPassword] = useState(true)
+  const [authProvider, setAuthProvider] = useState("")
+  const [isLoadingAuthType, setIsLoadingAuthType] = useState(false)
+
+  // Sub-step: Set Password (for social logins)
+  const [newPassword, setNewPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [isSettingPassword, setIsSettingPassword] = useState(false)
+  const [setPasswordErrorMsg, setSetPasswordErrorMsg] = useState("")
+
+  // Sub-step: Verify Password
+  const [password, setPassword] = useState("")
+  const [isVerifying, setIsVerifying] = useState(false)
+  const [verifyPasswordError, setVerifyPasswordError] = useState("")
+
+  // Sub-step: Final Confirmation
+  const [confirmText, setConfirmText] = useState("")
+  const [acknowledged, setAcknowledledged] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  // Check auth type when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setIsLoadingAuthType(true)
+      setFlowState("checking")
+      checkUserAuthType()
+        .then((res) => {
+          setHasPassword(res.hasPassword)
+          setAuthProvider(res.provider)
+          if (res.hasPassword) {
+            setFlowState("verify_password")
+          } else {
+            setFlowState("set_password")
+          }
+        })
+        .catch((err) => {
+          console.error("Error checking auth type:", err)
+          setFlowState("verify_password") // Fallback
+        })
+        .finally(() => {
+          setIsLoadingAuthType(false)
+        })
+    }
+  }, [isOpen])
+
+  const resetModal = () => {
+    setIsOpen(false)
+    setFlowState("checking")
+    setNewPassword("")
+    setConfirmPassword("")
+    setSetPasswordErrorMsg("")
+    setPassword("")
+    setVerifyPasswordError("")
+    setConfirmText("")
+    setAcknowledledged(false)
+    setIsSettingPassword(false)
+    setIsVerifying(false)
+    setIsDeleting(false)
+  }
+
+  // Handle setting password for social accounts
+  const handleSetPassword = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSetPasswordErrorMsg("")
+
+    if (!newPassword || !confirmPassword) {
+      setSetPasswordErrorMsg("Both password fields are required")
+      return
+    }
+
+    if (newPassword.length < 6) {
+      setSetPasswordErrorMsg("Password must be at least 6 characters")
+      return
+    }
+
+    if (newPassword !== confirmPassword) {
+      setSetPasswordErrorMsg("Passwords do not match")
+      return
+    }
+
+    setIsSettingPassword(true)
+
+    const result = await setInitialSocialPassword(newPassword)
+
+    setIsSettingPassword(false)
+
+    if (result.success) {
+      toast.success("Password successfully configured. Now, please verify it to proceed.")
+      setHasPassword(true)
+      // Reset input password field to blank and transition to verification
+      setPassword("")
+      setFlowState("verify_password")
+    } else {
+      setSetPasswordErrorMsg(result.error || "Failed to set password. Please try again.")
+      toast.error(result.error || "Failed to configure password")
+    }
+  }
+
+  // Handle password verification
+  const handleVerifyPassword = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setVerifyPasswordError("")
+
+    if (!password) {
+      setVerifyPasswordError("Password is required")
+      return
+    }
+
+    setIsVerifying(true)
+
+    const result = await verifyCurrentPassword(password)
+
+    setIsVerifying(false)
+
+    if (result.success) {
+      setFlowState("confirmation")
+    } else {
+      setVerifyPasswordError(result.error || "Incorrect password. Please try again.")
+      toast.error(result.error || "Incorrect password")
+    }
+  }
+
+  // Handle final account deletion
+  const handleDeleteAccount = async () => {
+    if (confirmText !== "DELETE") {
+      toast.error("Please type DELETE to confirm")
+      return
+    }
+    if (!acknowledged) {
+      toast.error("Please acknowledge the terms by ticking the checkbox")
+      return
+    }
+
+    setIsDeleting(true)
+
+    try {
+      const response = await fetch("/api/v1/account/delete", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          password: password, // Send the verified password
+        }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        toast.error(data.error || "Failed to delete account")
+        setIsDeleting(false)
+        return
+      }
+
+      toast.success("Your account and all associated data have been permanently deleted.")
+      
+      localStorage.clear()
+      sessionStorage.clear()
+
+      setTimeout(() => {
+        window.location.href = "/login"
+      }, 1500)
+    } catch (error) {
+      console.error("Account deletion error:", error)
+      toast.error("Network error. Please check your connection and try again.")
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !isDeleting && (open ? setIsOpen(true) : resetModal())}>
+      <DialogTrigger asChild>
+        <Button variant="destructive" className="gap-2 font-medium shadow-sm hover:shadow-destructive/20 transition-all">
+          <Trash2 className="h-4 w-4" />
+          Delete My Account
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-md border-destructive/20 bg-background/95 backdrop-blur-md">
+        <DialogHeader className="space-y-3">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+            {flowState === "set_password" ? (
+              <Key className="h-6 w-6 text-destructive" />
+            ) : flowState === "verify_password" ? (
+              <KeyRound className="h-6 w-6 text-destructive" />
+            ) : (
+              <ShieldAlert className="h-6 w-6 text-destructive" />
+            )}
+          </div>
+          <DialogTitle className="text-center font-bold tracking-tight text-xl">
+            {flowState === "set_password" && "Configure Account Password"}
+            {flowState === "verify_password" && "Verify Your Identity"}
+            {flowState === "confirmation" && "Confirm Permanent Deletion"}
+            {flowState === "checking" && "Securing Account Deletion"}
+          </DialogTitle>
+          <DialogDescription className="text-center text-muted-foreground text-sm">
+            {flowState === "set_password" && `Since you log in via ${authProvider || "social login"}, you must set a password first to secure this action.`}
+            {flowState === "verify_password" && "Enter your password to verify ownership before initiating deletion."}
+            {flowState === "confirmation" && "This is the final step. Review the checklist below before proceeding."}
+            {flowState === "checking" && "Loading account configuration details..."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Step Indicators */}
+        <div className="flex justify-center gap-1.5 py-1">
+          <div className={`h-1 rounded-full transition-all duration-300 ${flowState !== "checking" ? "w-8 bg-destructive" : "w-2 bg-muted"}`} />
+          <div className={`h-1 rounded-full transition-all duration-300 ${flowState === "verify_password" || flowState === "confirmation" ? "w-8 bg-destructive" : "w-2 bg-muted"}`} />
+          <div className={`h-1 rounded-full transition-all duration-300 ${flowState === "confirmation" ? "w-8 bg-destructive" : "w-2 bg-muted"}`} />
+        </div>
+
+        {isLoadingAuthType || flowState === "checking" ? (
+          <div className="flex flex-col items-center justify-center py-6 space-y-2">
+            <Loader2 className="h-8 w-8 animate-spin text-destructive" />
+            <p className="text-sm text-muted-foreground">Checking authentication state...</p>
+          </div>
+        ) : (
+          <>
+            {/* STEP: CONFIGURE PASSWORD (OAuth Users only) */}
+            {flowState === "set_password" && (
+              <form onSubmit={handleSetPassword} className="space-y-4 py-2">
+                <div className="space-y-3">
+                  <div className="space-y-1">
+                    <Label htmlFor="new-password">New Password</Label>
+                    <Input
+                      id="new-password"
+                      type="password"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      placeholder="At least 6 characters"
+                      className="bg-background/50 focus-visible:ring-destructive/30"
+                      disabled={isSettingPassword}
+                      autoFocus
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="confirm-new-password">Confirm Password</Label>
+                    <Input
+                      id="confirm-new-password"
+                      type="password"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      placeholder="Repeat new password"
+                      className="bg-background/50 focus-visible:ring-destructive/30"
+                      disabled={isSettingPassword}
+                    />
+                  </div>
+
+                  {setPasswordErrorMsg && (
+                    <p className="text-xs font-medium text-destructive flex items-center gap-1 mt-1">
+                      <AlertTriangle className="h-3 w-3" />
+                      {setPasswordErrorMsg}
+                    </p>
+                  )}
+                </div>
+
+                <DialogFooter className="gap-2 sm:gap-0 pt-2 border-t border-border/20">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={resetModal}
+                    disabled={isSettingPassword}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    variant="destructive"
+                    disabled={isSettingPassword}
+                    className="gap-2"
+                  >
+                    {isSettingPassword ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Setting Password...
+                      </>
+                    ) : (
+                      <>
+                        Configure Password
+                        <ArrowRight className="h-4 w-4" />
+                      </>
+                    )}
+                  </Button>
+                </DialogFooter>
+              </form>
+            )}
+
+            {/* STEP: VERIFY PASSWORD */}
+            {flowState === "verify_password" && (
+              <form onSubmit={handleVerifyPassword} className="space-y-4 py-2">
+                <div className="space-y-2">
+                  <Label htmlFor="current-password">Enter Password</Label>
+                  <Input
+                    id="current-password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value)
+                      setVerifyPasswordError("")
+                    }}
+                    placeholder="Enter your password to verify"
+                    className={`bg-background/50 focus-visible:ring-destructive/30 ${verifyPasswordError ? "border-destructive/60" : "border-border/60"}`}
+                    disabled={isVerifying}
+                    autoFocus
+                  />
+                  {verifyPasswordError && (
+                    <p className="text-xs font-medium text-destructive flex items-center gap-1 mt-1">
+                      <AlertTriangle className="h-3 w-3" />
+                      {verifyPasswordError}
+                    </p>
+                  )}
+                </div>
+
+                <DialogFooter className="gap-2 sm:gap-0 pt-2 border-t border-border/20">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={resetModal}
+                    disabled={isVerifying}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    variant="destructive"
+                    disabled={isVerifying}
+                    className="gap-2"
+                  >
+                    {isVerifying ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Verifying...
+                      </>
+                    ) : (
+                      <>
+                        Verify Password
+                        <ArrowRight className="h-4 w-4" />
+                      </>
+                    )}
+                  </Button>
+                </DialogFooter>
+              </form>
+            )}
+
+            {/* STEP: FINAL CONFIRMATION */}
+            {flowState === "confirmation" && (
+              <div className="space-y-4 py-2">
+                <div className="p-3.5 rounded-xl bg-destructive/5 border border-destructive/20 space-y-2 text-xs leading-relaxed text-muted-foreground">
+                  <p className="font-semibold text-destructive flex items-center gap-1.5 text-sm">
+                    <AlertTriangle className="h-4 w-4" />
+                    Data Deletion Checklist
+                  </p>
+                  <ul className="list-disc pl-4 space-y-1 mt-1 text-destructive/90 font-medium">
+                    <li>Your profile details & metadata will be deleted.</li>
+                    <li>All tracked habits, streaks, and journal logs will be erased.</li>
+                    <li>Any active premium subscriptions will be terminated.</li>
+                    <li>This action cannot be undone.</li>
+                  </ul>
+                </div>
+
+                <div className="flex items-start gap-2.5 py-1">
+                  <Checkbox
+                    id="acknowledge"
+                    checked={acknowledged}
+                    onCheckedChange={(checked) => setAcknowledledged(checked === true)}
+                    className="mt-1 data-[state=checked]:bg-destructive data-[state=checked]:border-destructive"
+                    disabled={isDeleting}
+                  />
+                  <label
+                    htmlFor="acknowledge"
+                    className="text-xs text-muted-foreground cursor-pointer leading-relaxed select-none"
+                  >
+                    I understand that all my personal data, reflections, and subscriptions will be deleted forever, and there is no way to restore my account.
+                  </label>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="confirm-delete" className="text-xs text-muted-foreground">
+                    Type <span className="font-bold text-foreground">DELETE</span> below to confirm:
+                  </Label>
+                  <Input
+                    id="confirm-delete"
+                    value={confirmText}
+                    onChange={(e) => setConfirmText(e.target.value.toUpperCase())}
+                    placeholder="DELETE"
+                    className="border-destructive/30 focus-visible:ring-destructive/40 text-center font-mono tracking-widest bg-background/50"
+                    disabled={isDeleting}
+                    autoComplete="off"
+                    autoFocus
+                  />
+                </div>
+
+                <DialogFooter className="gap-2 sm:gap-0 pt-2 border-t border-border/20">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => {
+                      // Allow going back to verify step
+                      setFlowState("verify_password")
+                    }}
+                    disabled={isDeleting}
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={handleDeleteAccount}
+                    disabled={confirmText !== "DELETE" || !acknowledged || isDeleting}
+                    className="gap-2"
+                  >
+                    {isDeleting ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Deleting Account...
+                      </>
+                    ) : (
+                      "Delete My Account Forever"
+                    )}
+                  </Button>
+                </DialogFooter>
+              </div>
+            )}
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/supabase/migrations/20260603_account_deletion_support.sql
+++ b/supabase/migrations/20260603_account_deletion_support.sql
@@ -1,0 +1,50 @@
+-- 20260603_account_deletion_support.sql
+
+-- Create the stored procedure to delete user data inside a transaction
+CREATE OR REPLACE FUNCTION delete_user_data(target_user_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  -- Step 1: Delete child records (foreign keys/dependencies) - order matters
+  DELETE FROM public.habit_logs WHERE user_id = target_user_id;
+  DELETE FROM public.daily_logs WHERE user_id = target_user_id;
+  DELETE FROM public.focus_sessions WHERE user_id = target_user_id;
+  DELETE FROM public.mood_logs WHERE user_id = target_user_id;
+  DELETE FROM public.journals WHERE user_id = target_user_id;
+  DELETE FROM public.tasks WHERE user_id = target_user_id;
+  DELETE FROM public.user_goals WHERE user_id = target_user_id;
+  DELETE FROM public.weekly_plan WHERE user_id = target_user_id;
+  DELETE FROM public.weekly_review WHERE user_id = target_user_id;
+  DELETE FROM public.notifications WHERE user_id = target_user_id;
+  DELETE FROM public.push_subscriptions WHERE user_id = target_user_id;
+  DELETE FROM public.user_preferences WHERE user_id = target_user_id;
+
+  -- Step 2: Delete main records
+  DELETE FROM public.habits WHERE user_id = target_user_id;
+  DELETE FROM public.profiles WHERE id = target_user_id;
+  DELETE FROM public.account_subscriptions WHERE user_id = target_user_id;
+  DELETE FROM public.billing_events WHERE user_id = target_user_id;
+END;
+$$ LANGUAGE plpgsql 
+SECURITY DEFINER 
+SET search_path = public;   -- Security best practice
+
+COMMENT ON FUNCTION delete_user_data(UUID) IS 'Deletes all user data in a single transaction. Called only from protected backend endpoint.';
+
+-- Create security definer function to check if the user has a password in auth.users
+CREATE OR REPLACE FUNCTION user_has_password(target_user_id UUID)
+RETURNS BOOLEAN AS $$
+DECLARE
+  has_pass BOOLEAN;
+BEGIN
+  SELECT (encrypted_password IS NOT NULL AND encrypted_password <> '')
+  INTO has_pass
+  FROM auth.users
+  WHERE id = target_user_id;
+  
+  RETURN COALESCE(has_pass, FALSE);
+END;
+$$ LANGUAGE plpgsql 
+SECURITY DEFINER 
+SET search_path = public;
+
+COMMENT ON FUNCTION user_has_password(UUID) IS 'Checks if a user has a password configured in auth.users securely bypassing RLS.';


### PR DESCRIPTION
Introduce a complete account deletion flow and related auth improvements. Adds a client AccountDeletionModal with multi-step flows (set password for social users, verify password, final confirmation) and a new POST API endpoint /api/v1/account/delete that verifies credentials, cancels active subscriptions, deletes user data (RPC fallback), and removes the Supabase auth user. Adds server-side auth helpers: verifyCurrentPassword, checkUserAuthType, setInitialSocialPassword, and changePasswordWithVerification to support social-login password setup and safe password updates. Update security/profile UIs to surface the danger zone and adapt password update dialogs for passwordless/social users. Include DB migration creating delete_user_data and user_has_password SECURITY DEFINER functions used by the backend for safe deletion and password checks.