### PR TITLE
Fix logo filename capitalization

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -157,7 +157,7 @@ const isCollapsed = state === "collapsed"
 <SidebarHeader className="px-2 pt-4 pb-2 flex flex-col gap-3">
   <div className="flex px-2">
     <div className="flex items-center justify-center rounded-md w-7 h-7 shrink-0 bg-sidebar-primary/5 border border-sidebar-border shadow-sm">
-      <Image alt="Rhythme Logo" src="/rhythme.svg" width={18} height={18} className="opacity-90" />
+      <Image alt="Rhythme Logo" src="/Rhythme.svg" width={18} height={18} className="opacity-90" />
     </div>
   </div>
 

--- a/components/beta/beta-hero.tsx
+++ b/components/beta/beta-hero.tsx
@@ -30,7 +30,7 @@ const BetaHero: React.FC = () => {
           <div className="absolute inset-0 bg-gradient-to-br from-primary/40 to-accent/40 rounded-full blur-2xl group-hover:blur-3xl transition-all duration-500 animate-pulse"></div>
           <div className="relative w-full h-full backdrop-blur-xl bg-background/60 border-2 border-primary/40 rounded-full flex items-center justify-center shadow-2xl shadow-primary/30">
             <Image 
-              src="/rhythme.svg" 
+              src="/Rhythme.svg" 
               alt="Rhythmé logo" 
               width={40} 
               height={40}

--- a/components/landing/about.tsx
+++ b/components/landing/about.tsx
@@ -126,7 +126,7 @@ const AboutPage: React.FC = () => {
               <div className="absolute inset-0 bg-gradient-to-br from-primary/30 to-accent/30 rounded-full blur-2xl"></div>
               <div className="relative w-full h-full backdrop-blur-xl bg-background/60 border-2 border-primary/30 rounded-full flex items-center justify-center shadow-2xl shadow-primary/20">
                 <Image 
-                  src="/rhythme.svg" 
+                  src="/Rhythme.svg" 
                   alt="Rhythmé logo" 
                   width={50} 
                   height={50}

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -90,7 +90,7 @@ const Footer: React.FC = () => {
                 <div className="absolute inset-0 bg-primary/20 blur-lg rounded-full group-hover:bg-primary/30 transition-all duration-500"></div>
                 <div className="relative backdrop-blur-sm bg-background/50 border border-primary/30 rounded-xl p-2 group-hover:border-primary/50 transition-all duration-500">
                   <Image 
-                    src="/rhythme.svg" 
+                    src="/Rhythme.svg" 
                     alt="Rhythmé logo" 
                     width={24} 
                     height={24}

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -141,7 +141,7 @@ const RhythmeLanding: React.FC<RhythmeLandingProps> = ({ user }) => {
             <div className="absolute inset-0 bg-gradient-to-br from-primary/30 to-accent/30 rounded-full blur-2xl group-hover:blur-3xl transition-all duration-700"></div>
             <div className="relative w-full h-full backdrop-blur-xl bg-background/60 border-2 border-primary/30 rounded-full flex items-center justify-center group-hover:border-primary/60 transition-all duration-500 group-hover:scale-105 shadow-2xl shadow-primary/20">
               <Image 
-                src="/rhythme.svg" 
+                src="/Rhythme.svg" 
                 alt="Rhythmé logo" 
                 width={50} 
                 height={50}

--- a/components/rhythme-logo.tsx
+++ b/components/rhythme-logo.tsx
@@ -43,7 +43,7 @@ export function RhythmeLogo({ size = "md", showText = true, className }: Rhythme
           current.box
         )}>
           <Image
-            src="/rhythme.svg"
+            src="/Rhythme.svg"
             alt="Rhythmé logo"
             width={current.img}
             height={current.img}


### PR DESCRIPTION
Update image src references from "/rhythme.svg" to "/Rhythme.svg" across multiple components to match the actual asset filename and prevent broken images on case-sensitive filesystems. Updated files: components/app-sidebar.tsx, components/beta/beta-hero.tsx, components/landing/about.tsx, components/landing/footer.tsx, components/landing/landing-page.tsx, components/rhythme-logo.tsx.